### PR TITLE
Added support for disabling dt2 validations loss computation.

### DIFF
--- a/juneberry/config/model.py
+++ b/juneberry/config/model.py
@@ -116,10 +116,12 @@ class PytorchOptions(Prodict):
 
 
 class Detectron2(Prodict):
+    disable_val_loss: bool
     metric_interval: int
     overrides: Prodict
 
     def init(self):
+        self.disable_val_loss = False
         self.metric_interval = 1
 
 

--- a/juneberry/config/model.py
+++ b/juneberry/config/model.py
@@ -116,12 +116,12 @@ class PytorchOptions(Prodict):
 
 
 class Detectron2(Prodict):
-    disable_val_loss: bool
+    enable_val_loss: bool
     metric_interval: int
     overrides: Prodict
 
     def init(self):
-        self.disable_val_loss = False
+        self.enable_val_loss = False
         self.metric_interval = 1
 
 

--- a/juneberry/detectron2/dt2_trainer.py
+++ b/juneberry/detectron2/dt2_trainer.py
@@ -363,8 +363,9 @@ class Detectron2Trainer(Trainer):
                 storage.put_scalar("lr", optimizer.param_groups[0]["lr"], smoothing_hint=False)
                 scheduler.step()
 
-                # Compute the loss for this step
-                self.loss_evaluator.after_step(self)
+                # Compute the loss for this step, if they want it
+                if not self.model_config.detectron2.disable_val_loss:
+                    self.loss_evaluator.after_step(self)
 
                 # and iteration != max_iter - 1
                 if cfg.TEST.EVAL_PERIOD > 0 and ((iteration + 1) % cfg.TEST.EVAL_PERIOD) == 0:

--- a/juneberry/detectron2/dt2_trainer.py
+++ b/juneberry/detectron2/dt2_trainer.py
@@ -364,7 +364,7 @@ class Detectron2Trainer(Trainer):
                 scheduler.step()
 
                 # Compute the loss for this step, if they want it
-                if not self.model_config.detectron2.disable_val_loss:
+                if self.model_config.detectron2.enable_val_loss:
                     self.loss_evaluator.after_step(self)
 
                 # and iteration != max_iter - 1

--- a/juneberry/documentation/model_configuration_specification.md
+++ b/juneberry/documentation/model_configuration_specification.md
@@ -21,6 +21,7 @@ import space. (e.g., relative to cwd or PYTHONPATH.)
     "batch_size": <The number of data samples to use per update when training or evaluating the model.>,
     "description": <OPTIONAL text description of the model in this file>,
     "detectron2": {
+        "disable_val_loss": <OPTIONAL; bool; set to true to disable validation loss computation.>
         "metric_interval": <OPTIONAL; integer; logs the training metrics to console every X iterations>,
         "overrides": [ <array of values to add to the config using merge_from_list> ]
     },
@@ -169,6 +170,10 @@ evaluating the model.
 
 ## detectron2
 Specific parameters for detectron2.  This is only used when the platform is detectron2.
+
+### disable_val_loss
+**Optional**: Set to true to disable validation loss computation. The validation loss computation may interact
+with some layers during training.
 
 ### metric_interval
 **Optional:** This field is an integer which controls how often detectron2 training will log the training 

--- a/juneberry/documentation/model_configuration_specification.md
+++ b/juneberry/documentation/model_configuration_specification.md
@@ -172,8 +172,8 @@ evaluating the model.
 Specific parameters for detectron2.  This is only used when the platform is detectron2.
 
 ### enable_val_loss
-**Optional**: Set to true to enable experimental validation loss computation. Beware: The validation loss computation may interact
-with some layers during training.
+**Optional**: Set to true to enable experimental validation loss computation. Beware: The validation loss computation 
+may interact with some layers during training.
 
 ### metric_interval
 **Optional:** This field is an integer which controls how often detectron2 training will log the training 

--- a/juneberry/documentation/model_configuration_specification.md
+++ b/juneberry/documentation/model_configuration_specification.md
@@ -21,7 +21,7 @@ import space. (e.g., relative to cwd or PYTHONPATH.)
     "batch_size": <The number of data samples to use per update when training or evaluating the model.>,
     "description": <OPTIONAL text description of the model in this file>,
     "detectron2": {
-        "disable_val_loss": <OPTIONAL; bool; set to true to disable validation loss computation.>
+        "enable_val_loss": <OPTIONAL; bool; set to true to enable experimental validation loss computation>,
         "metric_interval": <OPTIONAL; integer; logs the training metrics to console every X iterations>,
         "overrides": [ <array of values to add to the config using merge_from_list> ]
     },
@@ -171,8 +171,8 @@ evaluating the model.
 ## detectron2
 Specific parameters for detectron2.  This is only used when the platform is detectron2.
 
-### disable_val_loss
-**Optional**: Set to true to disable validation loss computation. The validation loss computation may interact
+### enable_val_loss
+**Optional**: Set to true to enable experimental validation loss computation. Beware: The validation loss computation may interact
 with some layers during training.
 
 ### metric_interval

--- a/juneberry/schemas/model_schema.json
+++ b/juneberry/schemas/model_schema.json
@@ -18,6 +18,7 @@
         "detectron2": {
             "type": "object",
             "properties": {
+                "disable_val_loss": { "type": "boolean" },
                 "metric_interval": { "type": "integer" },
                 "overrides": { "type": "array" }
             },

--- a/scripts/run_system_test.py
+++ b/scripts/run_system_test.py
@@ -98,7 +98,7 @@ OD_CPU_TEST_SET = [
     [
         "text_detect/dt2/ut",
         "data_sets/text_detect_val.json",
-        0.3,
+        0.23,
         0.00004
     ]
 ]


### PR DESCRIPTION
To test this add the "disable_val_loss" flag to the detectron2 training stanza.

``` python
    "detectron2": {
        "disable_val_loss": true,
```