### PR TITLE
Feature/jb 357 incorporate new coco prodict

### DIFF
--- a/juneberry/config/coco_anno.py
+++ b/juneberry/config/coco_anno.py
@@ -52,9 +52,9 @@ class License(Prodict):
 class Category(Prodict):
     id: int
     name: str
-    supercategory: str
-    isthing: int
-    color: List[int]
+    # supercategory: str
+    # isthing: int
+    # color: List[int]
 
 
 class Image(Prodict):

--- a/juneberry/config/coco_anno.py
+++ b/juneberry/config/coco_anno.py
@@ -1,0 +1,161 @@
+#! /usr/bin/env python3
+
+# ======================================================================================================================
+# Juneberry - General Release
+#
+# Copyright 2021 Carnegie Mellon University.
+#
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+#
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
+#
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
+#
+# DM21-0884
+#
+# ======================================================================================================================
+
+import logging
+import sys
+from prodict import List, Prodict, Any
+import juneberry.config.util as conf_utils
+import juneberry.filesystem as jbfs
+
+logger = logging.getLogger(__name__)
+
+
+# For more information about the COCO annotations data format, see https://cocodataset.org/#format-data
+
+
+class Info(Prodict):
+    year: int
+    version: str
+    description: str
+    contributor: str
+    url: str
+    date_created: str
+
+
+class License(Prodict):
+    id: int
+    name: str
+    url: str
+
+
+class Category(Prodict):
+    id: int
+    name: str
+    supercategory: str
+    isthing: int
+    color: List[int]
+
+
+class Image(Prodict):
+    id: int
+    width: int
+    height: int
+    file_name: str
+    license: int
+    flickr_url: str
+    coco_url: str
+    date_captured: str
+
+
+class Annotation(Prodict):
+    id: int
+    image_id: int
+    category_id: int
+    segmentation: Any
+    area: float
+    bbox: List[float]
+    iscrowd: int
+
+
+class CocoAnnotations(Prodict):
+    """
+    A class to validate and manage the coco annotations files.
+    """
+    FORMAT_VERSION = '1.2'
+    SCHEMA_NAME = 'coco_anno_schema.json'
+
+    info: Info
+    licenses: List[License]
+    categories: List[Category]
+    images: List[Image]
+    annotations: List[Annotation]
+
+    def _finish_init(self) -> None:
+        """
+        Validate coco fields
+        :return: None
+        """
+        error_count = 0
+
+        # Check for duplicate images
+        id_set = set()
+        for image in self.images:
+            if image.id in id_set:
+                logger.error(f"Found duplicate image id: id= '{image.id}'.")
+                error_count += 1
+            else:
+                id_set.add(image.id)
+
+        # If errors found, report and exit
+        if error_count > 0:
+            logger.error(f"Found {error_count} errors in experiment config. EXITING.")
+            sys.exit(-1)
+
+    @staticmethod
+    def construct(data: dict, file_path: str = None):
+        """
+        Load, validate, and construct a coco annotations object.
+        :param data: The data to use to construct the object.
+        :param file_path: Optional path to a file that may have been loaded. Used for logging.
+        :return: The constructed object.
+        """
+        # Convert category ids to integers
+        for index in range(0, len(data["categories"])):
+            data["categories"][index]["id"] = int(data["categories"][index]["id"])
+
+        # Validate with our schema
+        if not conf_utils.validate_schema(data, CocoAnnotations.SCHEMA_NAME):
+            logger.error(f"Validation errors in {file_path}. See log. EXITING.")
+            sys.exit(-1)
+
+        # Construct the CocoAnnotations object
+        config = CocoAnnotations.from_dict(data)
+        config._finish_init()
+        return config
+
+    @staticmethod
+    def load(data_path: str):
+        """
+        Loads the coco annotations file from the provided path, validates, and constructs the CocoAnnotations object.
+        :param data_path: Path to the coco annotations file.
+        :return: Loaded, validated, and constructed object.
+        """
+        # Load the raw file.
+        logger.info(f"Loading COCO ANNOTATIONS from {data_path}")
+        data = jbfs.load_file(data_path)
+
+        # Construct the config.
+        return CocoAnnotations.construct(data, data_path)
+
+    def save(self, data_path: str) -> None:
+        """
+        Save the coco annotations file to the specified resource path.
+        :param data_path: The path to the resource.
+        :return: None
+        """
+        conf_utils.validate_and_save_json(self.to_json(), data_path, CocoAnnotations.SCHEMA_NAME)
+
+    def to_json(self):
+        """ :return: A pure dictionary version suitable for serialization to json"""
+        return conf_utils.prodict_to_dict(self)

--- a/juneberry/config/coco_anno.py
+++ b/juneberry/config/coco_anno.py
@@ -24,7 +24,6 @@
 
 import logging
 import sys
-import typing
 from prodict import List, Prodict, Any
 import juneberry.config.util as conf_utils
 import juneberry.filesystem as jbfs

--- a/juneberry/config/coco_anno.py
+++ b/juneberry/config/coco_anno.py
@@ -35,11 +35,6 @@ logger = logging.getLogger(__name__)
 # For more information about the COCO annotations data format, see https://cocodataset.org/#format-data
 
 
-class Info(Prodict):
-    year: int
-    version: str
-
-
 class License(Prodict):
     id: int
     name: str
@@ -71,7 +66,7 @@ class CocoAnnotations(Prodict):
     FORMAT_VERSION = '1.2'
     SCHEMA_NAME = 'coco_anno_schema.json'
 
-    info: Info
+    info: dict
     licenses: List[License]
     categories: List[Category]
     images: List[Image]
@@ -109,6 +104,12 @@ class CocoAnnotations(Prodict):
         # Convert category ids to integers
         for index in range(0, len(data["categories"])):
             data["categories"][index]["id"] = int(data["categories"][index]["id"])
+
+        # Set info and licenses to their default data structures
+        if "info" not in data:
+            data["info"] = {}
+        if "licenses" not in data:
+            data["licenses"] = []
 
         # Validate with our schema
         if not conf_utils.validate_schema(data, CocoAnnotations.SCHEMA_NAME):

--- a/juneberry/config/coco_anno.py
+++ b/juneberry/config/coco_anno.py
@@ -24,6 +24,7 @@
 
 import logging
 import sys
+import typing
 from prodict import List, Prodict, Any
 import juneberry.config.util as conf_utils
 import juneberry.filesystem as jbfs
@@ -37,10 +38,6 @@ logger = logging.getLogger(__name__)
 class Info(Prodict):
     year: int
     version: str
-    description: str
-    contributor: str
-    url: str
-    date_created: str
 
 
 class License(Prodict):
@@ -52,9 +49,6 @@ class License(Prodict):
 class Category(Prodict):
     id: int
     name: str
-    # supercategory: str
-    # isthing: int
-    # color: List[int]
 
 
 class Image(Prodict):
@@ -62,20 +56,12 @@ class Image(Prodict):
     width: int
     height: int
     file_name: str
-    license: int
-    flickr_url: str
-    coco_url: str
-    date_captured: str
 
 
 class Annotation(Prodict):
     id: int
     image_id: int
     category_id: int
-    segmentation: Any
-    area: float
-    bbox: List[float]
-    iscrowd: int
 
 
 class CocoAnnotations(Prodict):

--- a/juneberry/config/coco_utils.py
+++ b/juneberry/config/coco_utils.py
@@ -236,7 +236,7 @@ def convert_predictions_to_annotations(predictions: list) -> list:
     return annos
 
 
-def convert_predictions_to_coco(coco_data: dict, predictions: list, category_list: List = None) -> dict:
+def convert_predictions_to_coco(coco_data: CocoAnnotations, predictions: list, category_list: List = None) -> dict:
     """
     Converts a predictions (detections) list to a coco formatted annotation file with images.
     :param coco_data: A base coco file with images.
@@ -245,13 +245,13 @@ def convert_predictions_to_coco(coco_data: dict, predictions: list, category_lis
     :return: coco formatted data
     """
     if not category_list:
-        category_list = coco_data['categories']
+        category_list = coco_data.categories
 
     return {
         "info": {
             "date_created": str(dt.now().replace(microsecond=0).isoformat())
         },
-        'images': coco_data['images'],
+        'images': coco_data.images,
         'annotations': convert_predictions_to_annotations(predictions),
         'categories': category_list
     }
@@ -351,7 +351,7 @@ def save_predictions_as_anno(data_root: Path, dataset_config: str, predict_file:
         # Alternatively, the dataset config should have a version of the metadata.
         dataset = DatasetConfig.load(dataset_config)
         coco_path = dataset.image_data.sources[0]['directory']
-        coco_data = jbfs.load_file(data_root / coco_path)
+        coco_data = CocoAnnotations.load(data_root / coco_path)
 
     predictions = jbfs.load_file(predict_file)
 

--- a/juneberry/config/coco_utils.py
+++ b/juneberry/config/coco_utils.py
@@ -345,7 +345,7 @@ def save_predictions_as_anno(data_root: Path, dataset_config: str, predict_file:
 
     # Obtain the coco metadata; the eval_manifest is higher priority.
     if eval_manifest_path:
-        coco_data = jbfs.load_file(str(eval_manifest_path))
+        coco_data = CocoAnnotations.load(str(eval_manifest_path))
 
     else:
         # Alternatively, the dataset config should have a version of the metadata.

--- a/juneberry/config/coco_utils.py
+++ b/juneberry/config/coco_utils.py
@@ -33,6 +33,7 @@ from random import shuffle as rand_shuffle
 import sys
 from typing import Dict, List
 from juneberry.config.dataset import DatasetConfig
+from juneberry.config.coco_anno import CocoAnnotations
 
 import juneberry.filesystem as jbfs
 
@@ -70,7 +71,7 @@ class COCOImageHelper:
         item.annotations[...]
     """
 
-    def __init__(self, data: dict, file_path=None):
+    def __init__(self, data: CocoAnnotations, file_path=None):
         """
         Creates a helper object to manage the coco annotations structure.
         :param data: The data such as one would get from a file
@@ -79,21 +80,21 @@ class COCOImageHelper:
         self.data = data
 
         # Image lookup
-        self.images = {i['id']: i for i in self.data['images']}
+        self.images = {i.id: i for i in self.data.images}
 
         # Annotations lookup
         self.annotations = defaultdict(list)
-        for anno in self.data['annotations']:
-            self.annotations[anno['image_id']].append(anno)
+        for anno in self.data.annotations:
+            self.annotations[anno.image_id].append(anno)
 
         # Optional file path for debugging
         self.file_path = file_path
 
         # Determine the maximum annotation ID so that new annotations receive the correct ID.
         self._next_annotation_id = -1
-        for anno in self.data['annotations']:
-            if anno['id'] > self._next_annotation_id:
-                self._next_annotation_id = anno['id']
+        for anno in self.data.annotations:
+            if anno.id > self._next_annotation_id:
+                self._next_annotation_id = anno.id
         self._next_annotation_id += 1
 
     def __contains__(self, item: int):
@@ -143,8 +144,8 @@ class COCOImageHelper:
         :param image_id: The image_id
         :return: None
         """
-        self.data['images'] = [i for i in self.data['images'] if i['id'] != image_id]
-        self.data['annotations'] = [i for i in self.data['annotations'] if i['image_id'] != image_id]
+        self.data.images = [i for i in self.data.images if i.id != image_id]
+        self.data.annotations = [i for i in self.data.annotations if i.image_id != image_id]
 
         # Remove from the quick lookups
         del self.images[image_id]
@@ -165,7 +166,7 @@ class COCOImageHelper:
         self._next_annotation_id += 1
 
         # Add it to the underlying store and the quick lookup
-        self.data['annotations'].append(annotation)
+        self.data.annotations.append(annotation)
         self.annotations[annotation['image_id']].append(annotation)
 
     def to_image_list(self):
@@ -192,7 +193,7 @@ class COCOImageHelper:
         are the human-readable string.
         :return:
         """
-        return {int(x["id"]): x["name"] for x in self.data['categories']}
+        return {int(x.id): x.name for x in self.data.categories}
 
 
 def load_from_json_file(file_path) -> COCOImageHelper:
@@ -201,7 +202,7 @@ def load_from_json_file(file_path) -> COCOImageHelper:
     :param file_path:
     :return: Constructed COCOImageHelper
     """
-    return COCOImageHelper(jbfs.load_file(file_path), file_path)
+    return COCOImageHelper(CocoAnnotations.load(file_path), file_path)
 
 
 def convert_predictions_to_annotations(predictions: list) -> list:
@@ -385,7 +386,7 @@ def generate_bbox_images(coco_json: Path, lab, dest_dir: str = None, sample_limi
         logger.info(f"The output directory was not found, so it was created.")
 
     # Load the COCO annotations.
-    coco = jbfs.load_file(coco_json)
+    coco = CocoAnnotations.load(str(coco_json))
         
     # Use a COCOImageHelper to obtain the legend.
     helper = COCOImageHelper(coco)

--- a/juneberry/data.py
+++ b/juneberry/data.py
@@ -405,12 +405,12 @@ class CocoMetadataMarshal(DatasetMarshal):
         # Then we add any more file annotation files
 
         logger.info(f"...loading: {filepath}...")
-        data = CocoAnnotations.load(filepath)
+        data = jbfs.load_file(filepath)
         if self._preprocessors is not None:
             logger.info(f"...applying ({len(self._preprocessors)}) preprocessors...")
-            orig_cats = copy.deepcopy(data.categories)
+            orig_cats = copy.deepcopy(data['categories'])
             data = self._preprocessors(data)
-            if orig_cats != data.categories:
+            if orig_cats != data['categories']:
                 logger.info(f"......changing categories because preprocessor changed them.")
                 # The categories were changed by the preprocessors. They win out over all others
                 # Categories is a list of id, name
@@ -418,12 +418,13 @@ class CocoMetadataMarshal(DatasetMarshal):
                 # NOTE: This might not be a good idea to do it every time depending on how the
                 # preprocessors are written, but we'll try this for a while.
                 # TODO: Fix the dichotomy with str vs int labels
-                str_labels = {str(x['id']): x['name'] for x in data.categories}
-                int_labels = {int(x['id']): x['name'] for x in data.categories}
+                str_labels = {str(x['id']): x['name'] for x in data['categories']}
+                int_labels = {int(x['id']): x['name'] for x in data['categories']}
                 self.ds_config.label_names = str_labels
                 self.ds_config.update_label_names(int_labels)
 
         # Now that we have the file loaded let's load the values
+        data = CocoAnnotations.load(filepath)
         helper = COCOImageHelper(data)
         if remove_image_ids:
             [helper.remove_image(img_id) for img_id in remove_image_ids]

--- a/juneberry/data.py
+++ b/juneberry/data.py
@@ -405,12 +405,12 @@ class CocoMetadataMarshal(DatasetMarshal):
         # Then we add any more file annotation files
 
         logger.info(f"...loading: {filepath}...")
-        data = jbfs.load_file(filepath)
+        data = CocoAnnotations.load(filepath)
         if self._preprocessors is not None:
             logger.info(f"...applying ({len(self._preprocessors)}) preprocessors...")
-            orig_cats = copy.deepcopy(data['categories'])
+            orig_cats = copy.deepcopy(data.categories)
             data = self._preprocessors(data)
-            if orig_cats != data['categories']:
+            if orig_cats != data.categories:
                 logger.info(f"......changing categories because preprocessor changed them.")
                 # The categories were changed by the preprocessors. They win out over all others
                 # Categories is a list of id, name
@@ -418,13 +418,12 @@ class CocoMetadataMarshal(DatasetMarshal):
                 # NOTE: This might not be a good idea to do it every time depending on how the
                 # preprocessors are written, but we'll try this for a while.
                 # TODO: Fix the dichotomy with str vs int labels
-                str_labels = {str(x['id']): x['name'] for x in data['categories']}
-                int_labels = {int(x['id']): x['name'] for x in data['categories']}
+                str_labels = {str(x['id']): x['name'] for x in data.categories}
+                int_labels = {int(x['id']): x['name'] for x in data.categories}
                 self.ds_config.label_names = str_labels
                 self.ds_config.update_label_names(int_labels)
 
         # Now that we have the file loaded let's load the values
-        data = CocoAnnotations.load(filepath)
         helper = COCOImageHelper(data)
         if remove_image_ids:
             [helper.remove_image(img_id) for img_id in remove_image_ids]

--- a/juneberry/data.py
+++ b/juneberry/data.py
@@ -418,8 +418,8 @@ class CocoMetadataMarshal(DatasetMarshal):
                 # NOTE: This might not be a good idea to do it every time depending on how the
                 # preprocessors are written, but we'll try this for a while.
                 # TODO: Fix the dichotomy with str vs int labels
-                str_labels = {str(x.id): x.name for x in data.categories}
-                int_labels = {int(x.id): x.name for x in data.categories}
+                str_labels = {str(x['id']): x['name'] for x in data.categories}
+                int_labels = {int(x['id']): x['name'] for x in data.categories}
                 self.ds_config.label_names = str_labels
                 self.ds_config.update_label_names(int_labels)
 

--- a/juneberry/schemas/coco_anno_schema.json
+++ b/juneberry/schemas/coco_anno_schema.json
@@ -11,9 +11,7 @@
                 "properties": {
                     "id": { "type": "integer" },
                     "name": { "type": "string" },
-                    "supercategory": {},
-                    "isthing": {},
-                    "color": {}
+                    "supercategory": { "type": "string" }
                 },
                 "required": [
                     "id",
@@ -31,10 +29,10 @@
                     "width": { "type": "integer" },
                     "height": { "type": "integer" },
                     "file_name": { "type": "string" },
-                    "license": {},
-                    "flickr_url": {},
-                    "coco_url": {},
-                    "date_captured": {}
+                    "license": { "type": "integer" },
+                    "flickr_url": { "type": "string" },
+                    "coco_url": { "type":  "string" },
+                    "date_captured": { "type":  "string" }
                 },
                 "required": [
                     "id",
@@ -59,7 +57,8 @@
                         "type": "array",
                         "items": { "type": "number" }
                     },
-                    "iscrowd": { "type": "integer" }
+                    "iscrowd": { "type": "integer" },
+                    "score": { "type": "number" }
                 },
                 "required": [
                     "id",

--- a/juneberry/schemas/coco_anno_schema.json
+++ b/juneberry/schemas/coco_anno_schema.json
@@ -2,30 +2,8 @@
     "$schema": "https://json-schema.org/draft-07/schema",
     "type": "object",
     "properties": {
-        "info": {
-            "type": "object",
-            "properties": {
-                "year": { "type": "integer" },
-                "version": { "type": "string" },
-                "description": { "type": "string" },
-                "contributor": { "type": "string" },
-                "url": { "type": "string" },
-                "date_created": { "type": "string" }
-            },
-            "additionalProperties": false
-        },
-        "licenses": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "id": { "type": "integer" },
-                    "name": { "type": "string" },
-                    "url": { "type": "string" }
-                },
-                "additionalProperties": false
-            }
-        },
+        "info": {},
+        "licenses": {},
         "categories": {
             "type": "array",
             "items": {
@@ -33,12 +11,9 @@
                 "properties": {
                     "id": { "type": "integer" },
                     "name": { "type": "string" },
-                    "supercategory": { "type": "string" },
-                    "isthing": { "type": "integer" },
-                    "color": {
-                        "type": "array",
-                        "items": { "type": "integer" }
-                    }
+                    "supercategory": {},
+                    "isthing": {},
+                    "color": {}
                 },
                 "required": [
                     "id",
@@ -56,10 +31,10 @@
                     "width": { "type": "integer" },
                     "height": { "type": "integer" },
                     "file_name": { "type": "string" },
-                    "license": { "type": "integer" },
-                    "flickr_url": { "type": "string" },
-                    "coco_url": { "type": "string" },
-                    "date_captured": { "type": "string" }
+                    "license": {},
+                    "flickr_url": {},
+                    "coco_url": {},
+                    "date_captured": {}
                 },
                 "required": [
                     "id",

--- a/juneberry/schemas/coco_anno_schema.json
+++ b/juneberry/schemas/coco_anno_schema.json
@@ -20,8 +20,8 @@
                 "type": "object",
                 "properties": {
                     "id": { "type": "integer"},
-                    "name": { "type": "integer" },
-                    "url": { "type": "integer"}
+                    "name": { "type": "string" },
+                    "url": { "type": "string"}
                 },
                 "required": [
                     "id",

--- a/juneberry/schemas/coco_anno_schema.json
+++ b/juneberry/schemas/coco_anno_schema.json
@@ -2,8 +2,35 @@
     "$schema": "https://json-schema.org/draft-07/schema",
     "type": "object",
     "properties": {
-        "info": {},
-        "licenses": {},
+        "info": {
+            "type": "object",
+            "properties": {
+                "year": { "type": "integer"},
+                "version": { "type": "string"},
+                "description": { "type": "string"},
+                "contributor": { "type": "string"},
+                "url": { "type": "string"},
+                "date_created": { "type": "string"}
+            },
+            "additionalProperties": false
+        },
+        "licenses": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer"},
+                    "name": { "type": "integer" },
+                    "url": { "type": "integer"}
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "url"
+                ],
+                "additionalProperties": false
+            }
+        },
         "categories": {
             "type": "array",
             "items": {

--- a/juneberry/schemas/coco_anno_schema.json
+++ b/juneberry/schemas/coco_anno_schema.json
@@ -1,0 +1,103 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+        "info": {
+            "type": "object",
+            "properties": {
+                "year": { "type": "integer" },
+                "version": { "type": "string" },
+                "description": { "type": "string" },
+                "contributor": { "type": "string" },
+                "url": { "type": "string" },
+                "date_created": { "type": "string" }
+            },
+            "additionalProperties": false
+        },
+        "licenses": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer" },
+                    "name": { "type": "string" },
+                    "url": { "type": "string" }
+                },
+                "additionalProperties": false
+            }
+        },
+        "categories": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer" },
+                    "name": { "type": "string" },
+                    "supercategory": { "type": "string" },
+                    "isthing": { "type": "integer" },
+                    "color": {
+                        "type": "array",
+                        "items": { "type": "integer" }
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "images": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer" },
+                    "width": { "type": "integer" },
+                    "height": { "type": "integer" },
+                    "file_name": { "type": "string" },
+                    "license": { "type": "integer" },
+                    "flickr_url": { "type": "string" },
+                    "coco_url": { "type": "string" },
+                    "date_captured": { "type": "string" }
+                },
+                "required": [
+                    "id",
+                    "width",
+                    "height",
+                    "file_name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "annotations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer" },
+                    "image_id": { "type": "integer" },
+                    "category_id": { "type": "integer" },
+                    "segmentation": {},
+                    "area": { "type": "number" },
+                    "bbox": {
+                        "type": "array",
+                        "items": { "type": "number" }
+                    },
+                    "iscrowd": { "type": "integer" }
+                },
+                "required": [
+                    "id",
+                    "image_id",
+                    "category_id"
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "required": [
+        "categories",
+        "images"
+    ],
+    "additionalProperties": false
+}

--- a/juneberry/transforms/metadata_preprocessors.py
+++ b/juneberry/transforms/metadata_preprocessors.py
@@ -47,6 +47,7 @@
 from collections import defaultdict
 import logging
 from juneberry.config.coco_utils import COCOImageHelper
+from juneberry.config.coco_anno import CocoAnnotations
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +127,7 @@ class LogLabel:
     """
 
     def __call__(self, data):
-        helper = COCOImageHelper(data)
+        helper = COCOImageHelper(CocoAnnotations.construct(data))
         for image, annotations in helper.values():
             logger.info(f"{image['file_name']} category_ids={[x['category_id'] for x in annotations]}")
 
@@ -137,7 +138,7 @@ class LogExtendedLabels:
     """
 
     def __call__(self, data):
-        helper = COCOImageHelper(data)
+        helper = COCOImageHelper(CocoAnnotations.construct(data))
         for image, annotations in helper.values():
             logger.info(f"{image['file_name']} "
                         f"extended_categories={[x.get('extended_categories', '') for x in annotations]}")

--- a/test/test_coco_annotations.py
+++ b/test/test_coco_annotations.py
@@ -1,0 +1,91 @@
+#! /usr/bin/env python3
+
+# ======================================================================================================================
+# Juneberry - General Release
+#
+# Copyright 2021 Carnegie Mellon University.
+#
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+#
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
+#
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
+#
+# DM21-0884
+#
+# ======================================================================================================================
+
+
+import unittest
+from juneberry.config.coco_anno import CocoAnnotations
+
+
+def make_basic_config():
+    # Based on https://blog.superannotate.com/coco-dataset-introduction/
+    return {
+        "info": {
+            "year": 2021,
+            "version": "1.2"
+        },
+        "licenses": [],
+        "categories": [
+            {
+                "id": 1,
+                "name": "poodle",
+                "supercategory": "dog",
+                "isthing": 1,
+                "color": [1, 0, 0]
+            },
+            {
+                "id": 2,
+                "name": "ragdoll",
+                "supercategory": "cat",
+                "isthing": 1,
+                "color": [2, 0, 0]
+            }
+        ],
+        "images": [
+            {
+                "id": 122214,
+                "width": 640,
+                "height": 640,
+                "file_name": "84.jpg",
+                "license": 1,
+                "date_captured": "2021-07-19  17:49"
+            }
+        ],
+        "annotations": [
+            {
+                "area": 600.4,
+                "iscrowd": 1,
+                "image_id": 122214,
+                "bbox": [473.05, 395.45, 38.65, 28.92],
+                "category_id": 1,
+                "id": 934
+            }
+        ]
+    }
+
+
+class TestCocoAnno(unittest.TestCase):
+    def test_config_basics(self):
+        config = make_basic_config()
+        coco_anno = CocoAnnotations.construct(config)
+        assert len(config['images']) == len(coco_anno['images'])
+        assert len(config['annotations']) == len(coco_anno['annotations'])
+
+    def test_duplicate_images(self):
+        config = make_basic_config()
+        config['images'].append(config['images'][0])
+
+        with self.assertRaises(SystemExit), self.assertLogs(level='ERROR') as log:
+            CocoAnnotations.construct(config)
+        message = "Found duplicate image id: id= '122214'."
+        self.assertIn(message, log.output[0])

--- a/test/test_coco_annotations.py
+++ b/test/test_coco_annotations.py
@@ -39,16 +39,12 @@ def make_basic_config():
             {
                 "id": 1,
                 "name": "poodle",
-                "supercategory": "dog",
-                "isthing": 1,
-                "color": [1, 0, 0]
+                "supercategory": "dog"
             },
             {
                 "id": 2,
                 "name": "ragdoll",
-                "supercategory": "cat",
-                "isthing": 1,
-                "color": [2, 0, 0]
+                "supercategory": "cat"
             }
         ],
         "images": [

--- a/test/test_coco_utils.py
+++ b/test/test_coco_utils.py
@@ -46,6 +46,7 @@
 
 from juneberry.config.coco_utils import COCOImageHelper
 import juneberry.config.coco_utils as coco_utils
+from juneberry.config.coco_anno import CocoAnnotations
 
 IMAGE_IDS = [2, 4, 8, 20]
 OBJECT_IDS = [[0, 1], [2, 3, 4], [5, 6, 7, 8], [9, 10]]
@@ -74,15 +75,16 @@ def create_annotation(image_idx, object_idx, image_ids, object_ids):
     }
 
 
-def make_sample_coco(image_ids, object_ids):
+def make_sample_coco(image_ids, object_ids) -> CocoAnnotations:
     images = [create_image(i, image_ids) for i in range(len(object_ids))]
     annos = [create_annotation(img_idx, obj_idx, image_ids, object_ids)
              for img_idx, anno_ids in enumerate(object_ids) for obj_idx in range(len(anno_ids))]
-    return {
+    data = {
         "images": images,
         "annotations": annos,
         "categories": [{"id": k, "name": v} for k, v in LABEL_MAP.items()]
     }
+    return CocoAnnotations.construct(data)
 
 
 def test_coco_helper_reading():

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -828,9 +828,15 @@ def test_get_category_list(monkeypatch, tmp_path):
     assert test_list_2 == category_list
     assert source == "train config"
 
-    # Check for a warning message
-    TestCase().assertIn("WARNING:juneberry.data:The evaluation category list does not match that of the eval_manifest:",
-                        cm.output[0])
+    # Check for warning message
+    TestCase().assertEqual(cm.output, ["WARNING:juneberry.data:The evaluation category list does not match that of the "
+                                       "eval_manifest:  category_list: [OrderedDict([('id', 0), ('name', 'zero')]), "
+                                       "OrderedDict([('id', 1), ('name', 'one')]), "
+                                       "OrderedDict([('id', 2), ('name', 'two')]), "
+                                       "OrderedDict([('id', 3), ('name', 'three')])]  "
+                                       "eval_manifest list: [OrderedDict([('id', 0), ('name', 'HINDI')]), "
+                                       "OrderedDict([('id', 1), ('name', 'ENGLISH')]), "
+                                       "OrderedDict([('id', 2), ('name', 'OTHER')])]"])
 
     # Test manifest case
     category_list, source = jb_data.get_category_list(eval_manifest_path=train_manifest_path,

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -145,7 +145,7 @@ def assert_correct_list(test_list, frodo_indexes, sam_indexes, data_root='data_r
         assert train[1] == correct_labels[idx]
 
 
-def test_generate_image_list(monkeypatch, tmp_path):
+def test_generate_image_list(monkeypatch):
     monkeypatch.setattr(juneberry.data, 'list_or_glob_dir', mock_list_or_glob_dir)
 
     dataset_struct = make_image_classification_config()
@@ -216,7 +216,7 @@ def test_generate_image_validation_split(monkeypatch, tmp_path):
         json.dump(config, out_file, indent=4)
 
     # TODO: Switch this to just use the internal data structure
-    model_config = ModelConfig.load(config_path)
+    model_config = ModelConfig.load(str(config_path))
     model_config.validation = {
         "algorithm": "random_fraction",
         "arguments": {
@@ -722,14 +722,14 @@ def test_make_balanced_dict():
     check_allocation(data_dict, result_dict)
 
 
-def mock_generate_image_list(root, ds, model_config=None, splitting_config=None):
+def mock_generate_image_list(splitting_config=None):
     if splitting_config is not None:
         return ['image_train'], ['image_val']
     else:
         return ['image_train'], []
 
 
-def mock_load_tabular_data(mc, ds):
+def mock_load_tabular_data(mc):
     if mc is not None:
         return ['tab_train'], ['tab_val']
     else:

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -797,9 +797,13 @@ def test_get_category_list(monkeypatch, tmp_path):
     model_manager = ModelManager(model_name)
     train_config = DatasetConfig.load("data_sets/text_detect_val.json")
     data_root = Path(tmp_path)
-    test_list_1 = [{'id': 0, 'name': 'HINDI'}, {'id': 1, 'name': 'ENGLISH'}, {'id': 2, 'name': 'OTHER'}]
-    test_list_2 = [{'id': 0, 'name': 'zero'}, {'id': 1, 'name': 'one'},
-                   {'id': 2, 'name': 'two'}, {'id': 3, 'name': 'three'}]
+    test_list_1 = [{'id': 0, 'name': 'HINDI'},
+                   {'id': 1, 'name': 'ENGLISH'},
+                   {'id': 2, 'name': 'OTHER'}]
+    test_list_2 = [{'id': 0, 'name': 'zero'},
+                   {'id': 1, 'name': 'one'},
+                   {'id': 2, 'name': 'two'},
+                   {'id': 3, 'name': 'three'}]
 
     # Make sample manifest files (if not instantiated already)
     train_manifest_path = model_manager.get_training_data_manifest_path()
@@ -824,15 +828,9 @@ def test_get_category_list(monkeypatch, tmp_path):
     assert test_list_2 == category_list
     assert source == "train config"
 
-    # Check for warning message
-    TestCase().assertEqual(cm.output, ["WARNING:juneberry.data:The evaluation category list does not match that of the "
-                                       "eval_manifest:  category_list: [OrderedDict([('id', 0), ('name', 'zero')]), "
-                                       "OrderedDict([('id', 1), ('name', 'one')]), "
-                                       "OrderedDict([('id', 2), ('name', 'two')]), "
-                                       "OrderedDict([('id', 3), ('name', 'three')])]  "
-                                       "eval_manifest list: [OrderedDict([('id', 0), ('name', 'HINDI')]), "
-                                       "OrderedDict([('id', 1), ('name', 'ENGLISH')]), "
-                                       "OrderedDict([('id', 2), ('name', 'OTHER')])]"])
+    # Check for a warning message
+    TestCase().assertIn("WARNING:juneberry.data:The evaluation category list does not match that of the eval_manifest:",
+                        cm.output[0])
 
     # Test manifest case
     category_list, source = jb_data.get_category_list(eval_manifest_path=train_manifest_path,

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -829,14 +829,8 @@ def test_get_category_list(monkeypatch, tmp_path):
     assert source == "train config"
 
     # Check for warning message
-    TestCase().assertEqual(cm.output, ["WARNING:juneberry.data:The evaluation category list does not match that of the "
-                                       "eval_manifest:  category_list: [OrderedDict([('id', 0), ('name', 'zero')]), "
-                                       "OrderedDict([('id', 1), ('name', 'one')]), "
-                                       "OrderedDict([('id', 2), ('name', 'two')]), "
-                                       "OrderedDict([('id', 3), ('name', 'three')])]  "
-                                       "eval_manifest list: [OrderedDict([('id', 0), ('name', 'HINDI')]), "
-                                       "OrderedDict([('id', 1), ('name', 'ENGLISH')]), "
-                                       "OrderedDict([('id', 2), ('name', 'OTHER')])]"])
+    TestCase().assertIn("WARNING:juneberry.data:The evaluation category list does not match that of the eval_manifest:",
+                        cm.output[0])
 
     # Test manifest case
     category_list, source = jb_data.get_category_list(eval_manifest_path=train_manifest_path,


### PR DESCRIPTION
- Integrated coco prodict into the coco_utils, data, and metadata_preprocessor files where applicable
- Removed optional fields from prodict classes in coco_anno.py
- Set optional fields in the schema to {} i.e. Any (tried OneOf to specify multiple possible types... that didn't work)
- Cleaned up test_data.py a bit