### PR TITLE
Bugfix/jb 368 logging issues

### DIFF
--- a/bin/jb_attack_to_rules
+++ b/bin/jb_attack_to_rules
@@ -120,7 +120,7 @@ class AttackMaker:
         new_dataset_path = self.attack_manager.get_experiment_dataset_path(count)
 
         # Retrieve the desired training dataset transformations, substitute in the unique property from the
-        # universe of supserset | disjoint args, and add the transform to the dataset config.
+        # universe of superset | disjoint args, and add the transform to the dataset config.
         training_watermarks = self.attack_config.watermarks.training_watermarks
         training_watermarks.kwargs.update(selection)
         dataset.data_transforms = {'seed': randint(0, 2 ** 32 - 1), 'transforms': [training_watermarks]}
@@ -590,13 +590,16 @@ def main():
     jbscripting.setup_args(parser)
     args = parser.parse_args()
 
+    # Set up logging.
+    jbscripting.setup_logging_for_script(args, "jb_attack_to_rules")
+
     # Setup an attack maker, construct the experiment datasets, and create the experiment rules.
     maker = AttackMaker(args)
     maker.build_attack_training_datasets()
     maker.create_rules(maker.attack_manager.get_experiment_rules())
 
     logger.info(f"Rules file has been created for experiment `{args.experimentName}`.")
-    logger.info(f"Done.")
+    logger.info(f"jb_attack_to_rules is done.")
 
 
 if __name__ == "__main__":

--- a/bin/jb_attack_to_rules
+++ b/bin/jb_attack_to_rules
@@ -591,7 +591,7 @@ def main():
     args = parser.parse_args()
 
     # Set up logging.
-    jbscripting.setup_logging_for_script(args, "jb_attack_to_rules")
+    jbscripting.setup_logging_for_script(args)
 
     # Setup an attack maker, construct the experiment datasets, and create the experiment rules.
     maker = AttackMaker(args)

--- a/bin/jb_experiment_to_rules
+++ b/bin/jb_experiment_to_rules
@@ -74,13 +74,12 @@ class RuleMaker:
             inputs = [model_mgr.get_model_config(), model_config.training_dataset_config_path]
             outputs = model_mgr.get_training_output_list()
             command = [JB_TRAIN_COMMAND, model_mgr.model_name]
-            doc = f"{JB_TRAIN_COMMAND} {model_mgr.model_name}"
 
             # Add the "--onnx" option to jb_train if an ONNX model was requested.
             if model.onnx:
                 command.append("--onnx")
-                doc += " --onnx"
 
+            doc = " ".join([str(x) for x in command])
             clean_extras = model_mgr.get_training_clean_extras_list()
             requirements = []
 
@@ -92,7 +91,7 @@ class RuleMaker:
             inputs = [model_mgr.get_model_config(), model_config.training_dataset_config_path]
             outputs = model_mgr.get_dry_run_output_list()
             command = [JB_TRAIN_COMMAND, model_mgr.model_name, '--dryrun']
-            doc = f"{JB_TRAIN_COMMAND} {model_mgr.model_name} --dryrun"
+            doc = " ".join([str(x) for x in command])
             clean_extras = model_mgr.get_dry_run_clean_extras_list()
             requirements = []
 
@@ -128,7 +127,7 @@ class RuleMaker:
                         command.append('--useTrainSplit')
                     if test.use_val_split:
                         command.append('--useValSplit')
-                    doc = f"{JB_EVALUATE_COMMAND} {model_mgr.model_name}  {test.dataset_path}"
+                    doc = " ".join([str(x) for x in command])
                     clean_extras = model_mgr.get_predictions_clean_extras_list()
                     requirements = [model['train_rule_id']]
 
@@ -189,7 +188,7 @@ class RuleMaker:
         outputs = [Path(output_dir, "pr_curve.png"), Path(output_dir, "pc_curve.png"),
                    Path(output_dir, "rc_curve.png"), Path(output_dir, "eval_metrics.csv")]
 
-        doc = f"{JB_PLOT_PR_COMMAND} --outputDir {output_dir} --logDir {log_dir}"
+        doc = " ".join([str(x) for x in command])
         clean_extras = []
         workflow = self.builder.get_workflow("main")
         workflow.add_rule(inputs, outputs, command, doc, clean_extras, requirements)
@@ -224,7 +223,7 @@ class RuleMaker:
 
         outputs = [output_path]
 
-        doc = f"{JB_PLOT_ROC_COMMAND} {output_path} --logDir {log_dir}"
+        doc = " ".join([str(x) for x in command])
         clean_extras = []
         workflow = self.builder.get_workflow("main")
         workflow.add_rule(inputs, outputs, command, doc, clean_extras, requirements)
@@ -276,7 +275,7 @@ class RuleMaker:
             else:
                 continue
 
-        doc = f"{JB_SUMMARY_COMMAND} {output_path} --logDir {log_dir}"
+        doc = " ".join([str(x) for x in command])
         clean_extras = []
 
         workflow = self.builder.get_workflow("main")

--- a/bin/jb_experiment_to_rules
+++ b/bin/jb_experiment_to_rules
@@ -158,11 +158,12 @@ class RuleMaker:
     def add_plot_pr(self, report: Report):
         # Obtain the output directory as a string.
         output_dir = str(self.experiment_manager.get_experiment_file(report.output_dir))
+        log_dir = str(self.experiment_manager.get_experiment_log_dir())
 
         # Accumulate all the tests into one report.
         inputs = []
         requirements = []
-        command = [JB_PLOT_PR_COMMAND, '--outputDir', output_dir]
+        command = [JB_PLOT_PR_COMMAND, '--outputDir', output_dir, '--logDir', log_dir]
 
         # Retrieve the desired IoU value for the command.
         if report.iou:
@@ -188,7 +189,7 @@ class RuleMaker:
         outputs = [Path(output_dir, "pr_curve.png"), Path(output_dir, "pc_curve.png"),
                    Path(output_dir, "rc_curve.png"), Path(output_dir, "eval_metrics.csv")]
 
-        doc = f"{JB_PLOT_PR_COMMAND} --outputDir {output_dir}"
+        doc = f"{JB_PLOT_PR_COMMAND} --outputDir {output_dir} --logDir {log_dir}"
         clean_extras = []
         workflow = self.builder.get_workflow("main")
         workflow.add_rule(inputs, outputs, command, doc, clean_extras, requirements)
@@ -197,11 +198,12 @@ class RuleMaker:
 
         # Everything gets put into one output
         output_path = str(self.experiment_manager.get_experiment_file(report.output_name))
+        log_dir = str(self.experiment_manager.get_experiment_log_dir())
 
         # Accumulate all the tests (predictions) into one report
         inputs = []
         requirements = []
-        command = [JB_PLOT_ROC_COMMAND, output_path]
+        command = [JB_PLOT_ROC_COMMAND, output_path, "--logDir", log_dir]
         for test in report.tests:
             predictions_file = str(self.tag_map[test.tag]['filename'])
             inputs.append(predictions_file)
@@ -222,7 +224,7 @@ class RuleMaker:
 
         outputs = [output_path]
 
-        doc = f"{JB_PLOT_ROC_COMMAND} {output_path}"
+        doc = f"{JB_PLOT_ROC_COMMAND} {output_path} --logDir {log_dir}"
         clean_extras = []
         workflow = self.builder.get_workflow("main")
         workflow.add_rule(inputs, outputs, command, doc, clean_extras, requirements)
@@ -240,6 +242,9 @@ class RuleMaker:
             csv_path = self.experiment_manager.get_experiment_file(report.csv_name)
             command.extend(['--csvFilename', csv_path])
             outputs.append(str(csv_path))
+            log_dir = self.experiment_manager.get_experiment_log_dir()
+            command.extend(['--logDir', log_dir])
+            outputs.append(str(log_dir / "log_jb_summary_report.txt"))
 
         for entry in self.tag_map.values():
             command.append('-f')
@@ -271,7 +276,7 @@ class RuleMaker:
             else:
                 continue
 
-        doc = f"{JB_SUMMARY_COMMAND} {output_path}"
+        doc = f"{JB_SUMMARY_COMMAND} {output_path} --logDir {log_dir}"
         clean_extras = []
 
         workflow = self.builder.get_workflow("main")
@@ -290,7 +295,7 @@ class RuleMaker:
             # Grab the filter from our map and fill in the entries.
             my_filter: Filter = self.filter_map.get(tag, None)
             if my_filter is None:
-                logger.error(f"Can't find filter {tag} in filter list. EXITING")
+                logger.error(f"Can't find filter {tag} in filter list. Exiting.")
                 sys.exit(-1)
 
             # Convert the replacement fields.
@@ -326,7 +331,7 @@ class RuleMaker:
         try:
             return arg.format(**replace_map)
         except KeyError:
-            logger.error(f"Failed to convert the arg '{arg}' in filter '{filter_tag}' during replacement. EXITING!")
+            logger.error(f"Failed to convert the arg '{arg}' in filter '{filter_tag}' during replacement. Exiting.")
             sys.exit(-1)
 
 
@@ -342,6 +347,8 @@ def main():
     maker = RuleMaker(args.experimentName)
     experiment_manager = jbfs.ExperimentManager(args.experimentName)
     maker.save(experiment_manager.get_experiment_rules())
+
+    logger.info(f"jb_experiment_to_rules is done.")
 
 
 if __name__ == "__main__":

--- a/bin/jb_plot_pr
+++ b/bin/jb_plot_pr
@@ -51,7 +51,7 @@ def setup_args(parser) -> None:
     parser.add_argument('--iou', type=float, default=0.5,
                         help="The IoU threshold to use when determining whether to count a detection as a true "
                              "positive.")
-    parser.add_argument('--outputDir', default=None,
+    parser.add_argument('--outputDir', default=Path.cwd(),
                         help="Directory where figures will be saved. If this field is left unspecified, the figures "
                              "will be saved to the current working directory.")
 
@@ -66,13 +66,13 @@ def main():
     jbscripting.setup_args(parser)
     args = parser.parse_args()
 
-    # If an output directory was not provided, default to the current working directory.
-    output_dir = Path.cwd() if args.outputDir is None else Path(args.outputDir)
+    # Create the output directory if it does not already exist.
+    output_dir = Path(args.outputDir)
     if not output_dir.exists():
         output_dir.mkdir(parents=True)
 
-    # Set up the workspace and logging.
-    jbscripting.setup_workspace(args, log_file=Path(output_dir, "log_plot_pr.txt"))
+    # Set up logging.
+    jbscripting.setup_logging_for_script(args, "jb_plot_pr")
 
     logger.info(f"Starting to generate PR, PC, and RC curves...")
 
@@ -103,6 +103,8 @@ def main():
 
     # Export the metrics as a CSV
     Metrics.export(metrics, output_dir / "eval_metrics.csv")
+
+    logger.info(f"jb_plot_pr is done.")
 
 
 if __name__ == "__main__":

--- a/bin/jb_plot_pr
+++ b/bin/jb_plot_pr
@@ -72,7 +72,7 @@ def main():
         output_dir.mkdir(parents=True)
 
     # Set up logging.
-    jbscripting.setup_logging_for_script(args, "jb_plot_pr")
+    jbscripting.setup_logging_for_script(args)
 
     logger.info(f"Starting to generate PR, PC, and RC curves...")
 

--- a/bin/jb_plot_roc
+++ b/bin/jb_plot_roc
@@ -350,7 +350,7 @@ def main():
     args = parser.parse_args()
 
     # Set up logging.
-    jbscripting.setup_logging_for_script(args, "jb_plot_roc")
+    jbscripting.setup_logging_for_script(args)
 
     # Some enforcement to make sure each file has a list of which classes to plot.
     if len(args.predictionFile) != len(args.plotClasses):

--- a/bin/jb_plot_roc
+++ b/bin/jb_plot_roc
@@ -1,46 +1,24 @@
 #! /usr/bin/env python3
 
 # ======================================================================================================================
-#  Copyright 2021 Carnegie Mellon University.
+# Juneberry - General Release
 #
-#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
-#  BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
-#  INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
-#  FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
-#  FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+# Copyright 2021 Carnegie Mellon University.
 #
-#  Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
 #
-#  [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.
-#  Please see Copyright notice for non-US Government use and distribution.
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
 #
-#  This Software includes and/or makes use of the following Third-Party Software subject to its own license:
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
 #
-#  1. PyTorch (https://github.com/pytorch/pytorch/blob/master/LICENSE) Copyright 2016 facebook, inc..
-#  2. NumPY (https://github.com/numpy/numpy/blob/master/LICENSE.txt) Copyright 2020 Numpy developers.
-#  3. Matplotlib (https://matplotlib.org/3.1.1/users/license.html) Copyright 2013 Matplotlib Development Team.
-#  4. pillow (https://github.com/python-pillow/Pillow/blob/master/LICENSE) Copyright 2020 Alex Clark and contributors.
-#  5. SKlearn (https://github.com/scikit-learn/sklearn-docbuilder/blob/master/LICENSE) Copyright 2013 scikit-learn
-#      developers.
-#  6. torchsummary (https://github.com/TylerYep/torch-summary/blob/master/LICENSE) Copyright 2020 Tyler Yep.
-#  7. pytest (https://docs.pytest.org/en/stable/license.html) Copyright 2020 Holger Krekel and others.
-#  8. pylint (https://github.com/PyCQA/pylint/blob/main/LICENSE) Copyright 1991 Free Software Foundation, Inc..
-#  9. Python (https://docs.python.org/3/license.html#psf-license) Copyright 2001 python software foundation.
-#  10. doit (https://github.com/pydoit/doit/blob/master/LICENSE) Copyright 2014 Eduardo Naufel Schettino.
-#  11. tensorboard (https://github.com/tensorflow/tensorboard/blob/master/LICENSE) Copyright 2017 The TensorFlow
-#                  Authors.
-#  12. pandas (https://github.com/pandas-dev/pandas/blob/master/LICENSE) Copyright 2011 AQR Capital Management, LLC,
-#             Lambda Foundry, Inc. and PyData Development Team.
-#  13. pycocotools (https://github.com/cocodataset/cocoapi/blob/master/license.txt) Copyright 2014 Piotr Dollar and
-#                  Tsung-Yi Lin.
-#  14. brambox (https://gitlab.com/EAVISE/brambox/-/blob/master/LICENSE) Copyright 2017 EAVISE.
-#  15. pyyaml  (https://github.com/yaml/pyyaml/blob/master/LICENSE) Copyright 2017 Ingy döt Net ; Kirill Simonov.
-#  16. natsort (https://github.com/SethMMorton/natsort/blob/master/LICENSE) Copyright 2020 Seth M. Morton.
-#  17. prodict  (https://github.com/ramazanpolat/prodict/blob/master/LICENSE.txt) Copyright 2018 Ramazan Polat
-#               (ramazanpolat@gmail.com).
-#  18. jsonschema (https://github.com/Julian/jsonschema/blob/main/COPYING) Copyright 2013 Julian Berman.
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
 #
-#  DM21-0689
+# DM21-0884
 #
 # ======================================================================================================================
 
@@ -48,7 +26,6 @@ import argparse
 import logging
 import matplotlib.pyplot as plt
 import numpy as np
-from pathlib import Path
 import re
 from sklearn.metrics import auc, roc_curve
 import sys
@@ -363,9 +340,6 @@ def setup_args(parser) -> None:
                              "For example, a scaling of 1.36 is good for around 25 items "
                              "while 1.12 is good for 50 items. You may need to fiddle with it a bit.")
     parser.add_argument('figureFilename', help="The name of the output file.")
-    parser.add_argument('--outputDir', default=None,
-                        help="Directory where figures will be saved. If this field is left unspecified, the figure "
-                             "will be saved to the current working directory.")
 
 
 def main():
@@ -375,10 +349,8 @@ def main():
     jbscripting.setup_args(parser)
     args = parser.parse_args()
 
-    # If an output directory was not provided, default to the current working directory.
-    output_dir = Path.cwd() if args.outputDir is None else Path(args.outputDir)
-    output_path = Path(output_dir, "log_plot_roc.txt")
-    jbscripting.setup_workspace(args, log_file=output_path)
+    # Set up logging.
+    jbscripting.setup_logging_for_script(args, "jb_plot_roc")
 
     # Some enforcement to make sure each file has a list of which classes to plot.
     if len(args.predictionFile) != len(args.plotClasses):
@@ -394,7 +366,7 @@ def main():
 
     generate_roc_plot(args.predictionFile, args.plotClasses, args.figureFilename, args.title, args.legendScaling)
 
-    logger.info("Done")
+    logger.info("jb_plot_roc is done.")
 
 
 if __name__ == "__main__":

--- a/bin/jb_process_dataset
+++ b/bin/jb_process_dataset
@@ -249,7 +249,7 @@ class TFDSProcessor(DatasetProcessor):
             np_image = image.numpy()
             label_num = int(label.numpy())
 
-            # PIL GRAYSCALE HACK does not like grayscale images as a dimenion of three it wants them as HxW only.
+            # PIL GRAYSCALE HACK does not like grayscale images as a dimension of three it wants them as HxW only.
             shape = np_image.shape
             if shape[2] == 1:
                 np_image = np_image.reshape(shape[0], shape[1])
@@ -354,8 +354,8 @@ def main():
             shutil.rmtree(str(out_dir_path))
         else:
             logger.error(f"{str(out_dir_path)} exists!")
-            logger.error(f"As a safety measure we will not overwrite an output directoy. Please delete the output "
-                         f"directory and try again. EXITING")
+            logger.error(f"As a safety measure we will not overwrite an output directory. Please delete the output "
+                         f"directory and try again. Exiting.")
             sys.exit(-1)
 
     logger.info(f"Making output directory {str(out_dir_path)}")
@@ -363,10 +363,10 @@ def main():
 
     # Follow the normal procedure for setting up logs and workspace
     log_prefix = ""
-    log_file = str(out_dir_path / "process_log.txt")
+    log_file = str(Path(args.logDir) / "process_log.txt")
     if args.dryrun:
         log_prefix = "<<DRY_RUN>> "
-        log_file = str(out_dir_path / "process_dryrun_log.txt")
+        log_file = str(Path(args.logDir) / "process_dryrun_log.txt")
     lab = jbscripting.setup_workspace(args, log_file=log_file, log_prefix=log_prefix,
                                       banner_msg=">>> Juneberry Dataset Preprocessor <<<")
 
@@ -379,6 +379,8 @@ def main():
     # Kick it off
     process_dataset(lab, ds_cfg, args.output_data_root, args.output_dir, args.output_config_path,
                     model_cfg=model_cfg, dryrun=args.dryrun)
+
+    logger.info(f"jb_process_dataset is done.")
 
 
 if __name__ == "__main__":

--- a/bin/jb_process_dataset
+++ b/bin/jb_process_dataset
@@ -359,7 +359,15 @@ def main():
             sys.exit(-1)
 
     logger.info(f"Making output directory {str(out_dir_path)}")
-    out_dir_path.mkdir()
+    out_dir_path.mkdir(parents=True)
+
+    # When an arg for the log directory is not provided, the default behavior is to save the log in
+    # the current directory. For this script, the desired behavior is to save the log to the output directory.
+    # You can't really tell if the cwd was intentionally chosen as the log dir, so the warning is needed.
+    if args.logDir == Path.cwd():
+        logger.warning(f"The log directory was detected as the current working directory. Changing the log dir to "
+                       f"match the output directory.")
+        args.logDir = out_dir_path
 
     # Follow the normal procedure for setting up logs and workspace
     log_prefix = ""

--- a/bin/jb_run_experiment
+++ b/bin/jb_run_experiment
@@ -62,68 +62,49 @@ def remove_for_regen(file_path: Path, commit) -> None:
             logger.info(f"Would remove {file_path} so that it gets regenerated.")
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Train a set of models, run a set of tests against them and "
-                    "produce a series of outputs into the experimentName directory. "
-                    "NOTE: By default this script reports what it WOULD do but does"
-                    "not perform any action. See --commit."
-                    "NOTE: This script executes other scripts in the same directory. "
-    )
-    parser.add_argument(
-        "experimentName", help="Name of the experiment in the experiments directory."
-    )
-    parser.add_argument(
-        "--commit", "-X",
-        default=False,
-        action="store_true",
-        help="Add this flag to execute the task. Otherwise the experiment will run in preview mode.",
-    )
-    parser.add_argument(
-        "--clean", "-C",
-        default=False,
-        action="store_true",
-        help="Clean the model, predictions and work files. Also requires --commit for results.",
-    )
-    parser.add_argument(
-        "--dryrun", "-D",
-        default=False,
-        action="store_true",
-        help="Apply --dryrun to to see a description of what execution would look like without actually"
-             "executing. Also requires --commit for results.",
-    )
-    parser.add_argument(
-        "--showcmd", "-S",
-        default=False,
-        action="store_true",
-        help="Set to true to show the command we execute or would execute.",
-    )
-    parser.add_argument(
-        "--rules", default=False, help="Path to custom rules.json file."
-    )
-    parser.add_argument(
-        "--processes", "-N",
-        type=int,
-        default=None,
-        help="This argument will override the default experiment behavior for jb_train, which uses all available "
-             "GPUs for a single jb_train. Instead, this argument launches an instance of jb_train that uses N GPUs, "
-             "so multiple models can be trained in parallel.")
-    parser.add_argument(
-        "--regen", "-R",
-        default=False,
-        action="store_true",
-        help="When this argument is provided, any existing experiment config or rules files will be deleted and "
-             "regenerated.")
+def setup_args(parser) -> None:
+    """
+    Adds arguments to the parser
+    :param parser: The parser in which to add arguments.
+    """
+    parser.add_argument("experimentName", help="Name of the experiment in the experiments directory.")
+    parser.add_argument("--commit", "-X", default=False, action="store_true",
+                        help="Add this flag to execute the task. Otherwise the experiment will run in preview mode.")
+    parser.add_argument("--clean", "-C", default=False, action="store_true",
+                        help="Clean the model, predictions and work files. Also requires --commit for results.")
+    parser.add_argument("--dryrun", "-D", default=False, action="store_true",
+                        help="Apply --dryrun to to see a description of what execution would look like without actually"
+                             "executing. Also requires --commit for results.")
+    parser.add_argument("--showcmd", "-S", default=False, action="store_true",
+                        help="Set to true to show the command we execute or would execute.")
+    parser.add_argument("--rules", default=False, help="Path to custom rules.json file.")
+    parser.add_argument("--processes", "-N", type=int, default=None,
+                        help="This argument will override the default experiment behavior for jb_train, which uses all "
+                             "available GPUs for a single jb_train. Instead, this argument launches an instance of "
+                             "jb_train that uses N GPUs, so multiple models can be trained in parallel.")
+    parser.add_argument("--regen", "-R", default=False, action="store_true",
+                        help="When this argument is provided, any existing experiment config or rules files will be "
+                             "deleted and regenerated.")
 
+
+def main():
+    parser = argparse.ArgumentParser(description="Train a set of models, run a set of tests against them and produce "
+                                                 "a series of outputs into the experimentName directory. NOTE: By "
+                                                 "default this script reports what it WOULD do but does not perform "
+                                                 "any action. See --commit. NOTE: This script executes other scripts "
+                                                 "in the same directory.")
+
+    setup_args(parser)
     jbscripting.setup_args(parser, add_data_root=True)
     args = parser.parse_args()
     show_command = args.showcmd
 
     # Set up logging
     experiment_manager = jbfs.ExperimentManager(args.experimentName)
-    log_prefix = "<<PREVIEW>> "
-    log_file = experiment_manager.get_experiment_dryrun_log_path()
-    if args.commit:
+    if args.dryrun:
+        log_prefix = "<<PREVIEW>> "
+        log_file = experiment_manager.get_experiment_dryrun_log_path()
+    else:
         log_prefix = "<<LIVE>> "
         log_file = experiment_manager.get_experiment_log_path()
     lab = jbscripting.setup_workspace(args, log_file=log_file, log_prefix=log_prefix)
@@ -133,10 +114,7 @@ def main():
     logger.info(f"Using bin directory: {bin_dir}")
 
     # Generate appropriate dodo.py file for the workflow
-    if args.dryrun:
-        workflow = "dryrun"
-    else:
-        workflow = "main"
+    workflow = "dryrun" if args.dryrun else "main"
 
     # Determine the location of the experiment outline file.
     exp_creator = jbfs.ExperimentCreator(args.experimentName)
@@ -210,12 +188,9 @@ def main():
     # Clean mode
     if args.clean:
         if args.commit:
-            if args.dryrun:
-                logger.info(f"Cleaning the DRYRUN workflow for {args.experimentName}")
-                cmd_args.append("clean")
-            else:
-                logger.info(f"Cleaning the MAIN workflow for {args.experimentName}")
-                cmd_args.append("clean")
+            logger.info(f"Cleaning the {workflow.upper()} workflow for {args.experimentName}")
+            cmd_args.append("clean")
+
         else:
             logger.info("The following tasks would be cleaned:")
             cmd_args.append("list")
@@ -224,10 +199,8 @@ def main():
     # Execution mode
     else:
         if args.commit:
-            if args.dryrun:
-                logger.info(f"Executing DRYRUN workflow for {args.experimentName}.")
-            else:
-                logger.info(f"Executing MAIN workflow for {args.experimentName}.")
+            logger.info(f"Executing {workflow.upper()} workflow for {args.experimentName}.")
+
         else:
             logger.info("The following tasks could be executed, check status:")
             logger.info("R: run, U: up-to-date, I: ignored")
@@ -248,7 +221,7 @@ def main():
             logger.info("Removing " + str(dodo_path))
             dodo_path.unlink()
 
-    logger.info("Done")
+    logger.info("jb_run_experiment is done.")
 
 
 if __name__ == "__main__":

--- a/bin/jb_run_plugin
+++ b/bin/jb_run_plugin
@@ -74,7 +74,7 @@ def main():
     args = parser.parse_args()
 
     # Set up logging.
-    jbscripting.setup_logging_for_script(args, "jb_run_plugin")
+    jbscripting.setup_logging_for_script(args)
 
     # Run the plugin.
     run_plugin(args.pluginFile)

--- a/bin/jb_run_plugin
+++ b/bin/jb_run_plugin
@@ -73,8 +73,13 @@ def main():
     jbscripting.setup_args(parser)
     args = parser.parse_args()
 
+    # Set up logging.
+    jbscripting.setup_logging_for_script(args, "jb_run_plugin")
+
     # Run the plugin.
     run_plugin(args.pluginFile)
+
+    logger.info(f"jb_run_plugin is done.")
 
 
 if __name__ == "__main__":

--- a/bin/jb_summary_report
+++ b/bin/jb_summary_report
@@ -31,6 +31,7 @@ import sys
 from juneberry.config.eval_output import EvaluationOutput
 from juneberry.config.training_output import TrainingOutput
 from juneberry.filesystem import ModelManager
+import juneberry.scripting as jbscripting
 
 logger = logging.getLogger("juneberry.jb_summary_report")
 
@@ -92,7 +93,7 @@ def determine_shared_metric(prediction_file_list: list) -> str:
         metric = "Accuracy"
 
     # If each prediction file contains the same type of metric, that metric must be the shared metric.
-    logging.info(f"Building a report to summarize {metric}.")
+    logger.info(f"Building a report to summarize {metric}.")
 
     return metric
 
@@ -164,7 +165,7 @@ def generate_summary_report(prediction_files: list, plot_files: list, summary_fi
         # Loop through the prediction files.
         for file in prediction_files:
 
-            logging.info(f"Adding the data from {file} to the summary report.")
+            logger.info(f"Adding the data from {file} to the summary report.")
 
             prediction_data = EvaluationOutput.load(file)
             model_name = prediction_data.options.model.name
@@ -223,11 +224,11 @@ def generate_summary_report(prediction_files: list, plot_files: list, summary_fi
             outFile.write("---\n".join([f"![Plot Image]({p.replace(' ', '%20')})\n" for p in plot_files]))
 
 
-def main():
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
-
-    parser = argparse.ArgumentParser(
-        description='This script will generate a markdown summary report of an experiment.')
+def setup_args(parser) -> None:
+    """
+    Adds arguments to the parser
+    :param parser: The parser in which to add arguments.
+    """
     parser.add_argument('-f', '--predictionFile', action='append', required=True,
                         help="The name of a file containing the prediction data to use. The expected format is "
                              "described in the predictions_specification. You can specify this argument multiple "
@@ -237,8 +238,19 @@ def main():
     parser.add_argument('summaryFilename', help="Markdown report will be written to this file")
     parser.add_argument('--csvFilename', default=None, required=False, help="CSV file to write summary table data")
 
+
+def main():
+    parser = argparse.ArgumentParser(description='This script generates a markdown summary report of an experiment.')
+    setup_args(parser)
+    jbscripting.setup_args(parser)
     args = parser.parse_args()
+
+    # Set up logging.
+    jbscripting.setup_logging_for_script(args, "jb_summary_report")
+
     generate_summary_report(args.predictionFile, args.plotFile, args.summaryFilename, args.csvFilename)
+
+    logger.info(f"jb_summary_report is done.")
 
 
 if __name__ == "__main__":

--- a/bin/jb_summary_report
+++ b/bin/jb_summary_report
@@ -246,7 +246,7 @@ def main():
     args = parser.parse_args()
 
     # Set up logging.
-    jbscripting.setup_logging_for_script(args, "jb_summary_report")
+    jbscripting.setup_logging_for_script(args)
 
     generate_summary_report(args.predictionFile, args.plotFile, args.summaryFilename, args.csvFilename)
 

--- a/bin/jb_train
+++ b/bin/jb_train
@@ -188,6 +188,8 @@ def main():
         else:
             trainer.train_distributed(trainer.num_gpus)
 
+    logger.info(f"jb_train is done.")
+
 
 if __name__ == "__main__":
     jbscripting.run_main(main, logger)

--- a/juneberry/architectures/pytorch/simple_cnn_28x28.py
+++ b/juneberry/architectures/pytorch/simple_cnn_28x28.py
@@ -1,46 +1,24 @@
 #! /usr/bin/env python3
 
 # ======================================================================================================================
-#  Copyright 2021 Carnegie Mellon University.
+# Juneberry - General Release
 #
-#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
-#  BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
-#  INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
-#  FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
-#  FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+# Copyright 2021 Carnegie Mellon University.
 #
-#  Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
 #
-#  [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.
-#  Please see Copyright notice for non-US Government use and distribution.
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
 #
-#  This Software includes and/or makes use of the following Third-Party Software subject to its own license:
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
 #
-#  1. PyTorch (https://github.com/pytorch/pytorch/blob/master/LICENSE) Copyright 2016 facebook, inc..
-#  2. NumPY (https://github.com/numpy/numpy/blob/master/LICENSE.txt) Copyright 2020 Numpy developers.
-#  3. Matplotlib (https://matplotlib.org/3.1.1/users/license.html) Copyright 2013 Matplotlib Development Team.
-#  4. pillow (https://github.com/python-pillow/Pillow/blob/master/LICENSE) Copyright 2020 Alex Clark and contributors.
-#  5. SKlearn (https://github.com/scikit-learn/sklearn-docbuilder/blob/master/LICENSE) Copyright 2013 scikit-learn 
-#      developers.
-#  6. torchsummary (https://github.com/TylerYep/torch-summary/blob/master/LICENSE) Copyright 2020 Tyler Yep.
-#  7. pytest (https://docs.pytest.org/en/stable/license.html) Copyright 2020 Holger Krekel and others.
-#  8. pylint (https://github.com/PyCQA/pylint/blob/main/LICENSE) Copyright 1991 Free Software Foundation, Inc..
-#  9. Python (https://docs.python.org/3/license.html#psf-license) Copyright 2001 python software foundation.
-#  10. doit (https://github.com/pydoit/doit/blob/master/LICENSE) Copyright 2014 Eduardo Naufel Schettino.
-#  11. tensorboard (https://github.com/tensorflow/tensorboard/blob/master/LICENSE) Copyright 2017 The TensorFlow 
-#                  Authors.
-#  12. pandas (https://github.com/pandas-dev/pandas/blob/master/LICENSE) Copyright 2011 AQR Capital Management, LLC,
-#             Lambda Foundry, Inc. and PyData Development Team.
-#  13. pycocotools (https://github.com/cocodataset/cocoapi/blob/master/license.txt) Copyright 2014 Piotr Dollar and
-#                  Tsung-Yi Lin.
-#  14. brambox (https://gitlab.com/EAVISE/brambox/-/blob/master/LICENSE) Copyright 2017 EAVISE.
-#  15. pyyaml  (https://github.com/yaml/pyyaml/blob/master/LICENSE) Copyright 2017 Ingy döt Net ; Kirill Simonov.
-#  16. natsort (https://github.com/SethMMorton/natsort/blob/master/LICENSE) Copyright 2020 Seth M. Morton.
-#  17. prodict  (https://github.com/ramazanpolat/prodict/blob/master/LICENSE.txt) Copyright 2018 Ramazan Polat
-#               (ramazanpolat@gmail.com).
-#  18. jsonschema (https://github.com/Julian/jsonschema/blob/main/COPYING) Copyright 2013 Julian Berman.
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
 #
-#  DM21-0689
+# DM21-0884
 #
 # ======================================================================================================================
 
@@ -79,7 +57,7 @@ class mnist_CNN(nn.Module):
 class CNN28x28:
     def __call__(self, img_width, img_height, channels, num_classes):
         if img_width != 28 or img_height != 28:
-            logging.error("The model only works with 28x28 images.")
+            logger.error("The model only works with 28x28 images.")
             sys.exit(-1)
         model = mnist_CNN(channels)
         return model

--- a/juneberry/architectures/pytorch/torchvision.py
+++ b/juneberry/architectures/pytorch/torchvision.py
@@ -1,46 +1,24 @@
 #! /usr/bin/env python3
 
 # ======================================================================================================================
-#  Copyright 2021 Carnegie Mellon University.
+# Juneberry - General Release
 #
-#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
-#  BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
-#  INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
-#  FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
-#  FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+# Copyright 2021 Carnegie Mellon University.
 #
-#  Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
 #
-#  [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.
-#  Please see Copyright notice for non-US Government use and distribution.
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
 #
-#  This Software includes and/or makes use of the following Third-Party Software subject to its own license:
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
 #
-#  1. PyTorch (https://github.com/pytorch/pytorch/blob/master/LICENSE) Copyright 2016 facebook, inc..
-#  2. NumPY (https://github.com/numpy/numpy/blob/master/LICENSE.txt) Copyright 2020 Numpy developers.
-#  3. Matplotlib (https://matplotlib.org/3.1.1/users/license.html) Copyright 2013 Matplotlib Development Team.
-#  4. pillow (https://github.com/python-pillow/Pillow/blob/master/LICENSE) Copyright 2020 Alex Clark and contributors.
-#  5. SKlearn (https://github.com/scikit-learn/sklearn-docbuilder/blob/master/LICENSE) Copyright 2013 scikit-learn
-#      developers.
-#  6. torchsummary (https://github.com/TylerYep/torch-summary/blob/master/LICENSE) Copyright 2020 Tyler Yep.
-#  7. pytest (https://docs.pytest.org/en/stable/license.html) Copyright 2020 Holger Krekel and others.
-#  8. pylint (https://github.com/PyCQA/pylint/blob/main/LICENSE) Copyright 1991 Free Software Foundation, Inc..
-#  9. Python (https://docs.python.org/3/license.html#psf-license) Copyright 2001 python software foundation.
-#  10. doit (https://github.com/pydoit/doit/blob/master/LICENSE) Copyright 2014 Eduardo Naufel Schettino.
-#  11. tensorboard (https://github.com/tensorflow/tensorboard/blob/master/LICENSE) Copyright 2017 The TensorFlow
-#                  Authors.
-#  12. pandas (https://github.com/pandas-dev/pandas/blob/master/LICENSE) Copyright 2011 AQR Capital Management, LLC,
-#             Lambda Foundry, Inc. and PyData Development Team.
-#  13. pycocotools (https://github.com/cocodataset/cocoapi/blob/master/license.txt) Copyright 2014 Piotr Dollar and
-#                  Tsung-Yi Lin.
-#  14. brambox (https://gitlab.com/EAVISE/brambox/-/blob/master/LICENSE) Copyright 2017 EAVISE.
-#  15. pyyaml  (https://github.com/yaml/pyyaml/blob/master/LICENSE) Copyright 2017 Ingy döt Net ; Kirill Simonov.
-#  16. natsort (https://github.com/SethMMorton/natsort/blob/master/LICENSE) Copyright 2020 Seth M. Morton.
-#  17. prodict  (https://github.com/ramazanpolat/prodict/blob/master/LICENSE.txt) Copyright 2018 Ramazan Polat
-#               (ramazanpolat@gmail.com).
-#  18. jsonschema (https://github.com/Julian/jsonschema/blob/main/COPYING) Copyright 2013 Julian Berman.
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
 #
-#  DM21-0689
+# DM21-0884
 #
 # ======================================================================================================================
 
@@ -129,10 +107,10 @@ class ResNetCustom(nn.Module):
 class Resnet32x32:
     def __call__(self, img_width, img_height, channels, num_classes, layers):
         if img_width != 32 or img_height != 32 or channels != 3:
-            logging.error("The model only works with 32x32 RGB images.")
+            logger.error("The model only works with 32x32 RGB images.")
             sys.exit(-1)
         elif (layers - 2) % 6 != 0:
-            logging.error("Layers argument missing or incorrect. (Layers - 2) % 6 must be zero for ResNet6n2.")
+            logger.error("Layers argument missing or incorrect. (Layers - 2) % 6 must be zero for ResNet6n2.")
             sys.exit(-1)
         else:
             model = ResNetCustom(block=BB, n=int((layers - 2) / 6), num_classes=num_classes)
@@ -179,10 +157,10 @@ class PreactResNetCustom(ResNetCustom):
 class PreActResnet32x32:
     def __call__(self, img_width, img_height, channels, num_classes, layers):
         if img_width != 32 or img_height != 32 or channels != 3:
-            logging.error("The model only works with 32x32 RGB images.")
+            logger.error("The model only works with 32x32 RGB images.")
             sys.exit(-1)
         elif (layers - 2) % 6 != 0:
-            logging.error("Layers argument missing or incorrect. (Layers - 2) % 6 must be zero for ResNet6n2.")
+            logger.error("Layers argument missing or incorrect. (Layers - 2) % 6 must be zero for ResNet6n2.")
             sys.exit(-1)
         else:
             model = PreactResNetCustom(block=PreActBB, n=int((layers - 2) / 6), num_classes=num_classes)

--- a/juneberry/config/util.py
+++ b/juneberry/config/util.py
@@ -1,46 +1,24 @@
 #! /usr/bin/env python3
 
 # ======================================================================================================================
-#  Copyright 2021 Carnegie Mellon University.
+# Juneberry - General Release
 #
-#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
-#  BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
-#  INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
-#  FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
-#  FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+# Copyright 2021 Carnegie Mellon University.
 #
-#  Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
 #
-#  [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.
-#  Please see Copyright notice for non-US Government use and distribution.
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
 #
-#  This Software includes and/or makes use of the following Third-Party Software subject to its own license:
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
 #
-#  1. PyTorch (https://github.com/pytorch/pytorch/blob/master/LICENSE) Copyright 2016 facebook, inc..
-#  2. NumPY (https://github.com/numpy/numpy/blob/master/LICENSE.txt) Copyright 2020 Numpy developers.
-#  3. Matplotlib (https://matplotlib.org/3.1.1/users/license.html) Copyright 2013 Matplotlib Development Team.
-#  4. pillow (https://github.com/python-pillow/Pillow/blob/master/LICENSE) Copyright 2020 Alex Clark and contributors.
-#  5. SKlearn (https://github.com/scikit-learn/sklearn-docbuilder/blob/master/LICENSE) Copyright 2013 scikit-learn 
-#      developers.
-#  6. torchsummary (https://github.com/TylerYep/torch-summary/blob/master/LICENSE) Copyright 2020 Tyler Yep.
-#  7. pytest (https://docs.pytest.org/en/stable/license.html) Copyright 2020 Holger Krekel and others.
-#  8. pylint (https://github.com/PyCQA/pylint/blob/main/LICENSE) Copyright 1991 Free Software Foundation, Inc..
-#  9. Python (https://docs.python.org/3/license.html#psf-license) Copyright 2001 python software foundation.
-#  10. doit (https://github.com/pydoit/doit/blob/master/LICENSE) Copyright 2014 Eduardo Naufel Schettino.
-#  11. tensorboard (https://github.com/tensorflow/tensorboard/blob/master/LICENSE) Copyright 2017 The TensorFlow 
-#                  Authors.
-#  12. pandas (https://github.com/pandas-dev/pandas/blob/master/LICENSE) Copyright 2011 AQR Capital Management, LLC,
-#             Lambda Foundry, Inc. and PyData Development Team.
-#  13. pycocotools (https://github.com/cocodataset/cocoapi/blob/master/license.txt) Copyright 2014 Piotr Dollar and
-#                  Tsung-Yi Lin.
-#  14. brambox (https://gitlab.com/EAVISE/brambox/-/blob/master/LICENSE) Copyright 2017 EAVISE.
-#  15. pyyaml  (https://github.com/yaml/pyyaml/blob/master/LICENSE) Copyright 2017 Ingy döt Net ; Kirill Simonov.
-#  16. natsort (https://github.com/SethMMorton/natsort/blob/master/LICENSE) Copyright 2020 Seth M. Morton.
-#  17. prodict  (https://github.com/ramazanpolat/prodict/blob/master/LICENSE.txt) Copyright 2018 Ramazan Polat
-#               (ramazanpolat@gmail.com).
-#  18. jsonschema (https://github.com/Julian/jsonschema/blob/main/COPYING) Copyright 2013 Julian Berman.
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
 #
-#  DM21-0689
+# DM21-0884
 #
 # ======================================================================================================================
 
@@ -105,7 +83,7 @@ def validate_schema(data, schema_name, die_on_error=False):
         error_count += 1
 
     if error_count:
-        logging.error(f"Found {error_count} errors validating against schema={schema_name}")
+        logger.error(f"Found {error_count} errors validating against schema={schema_name}")
         if die_on_error:
             type_name = type(data).__name__
             logger.error(f"Validation errors in {type_name}. See log. EXITING!")
@@ -139,7 +117,7 @@ def validate_and_save_json(json_data: dict, data_path: str, schema_name: str) ->
 
     # TODO: Add support in filesystem for different serializers - yaml, toml
     if data_path.suffix != ".json":
-        logging.error(f"We currently only support saving configs to json. {data_path}")
+        logger.error(f"We currently only support saving configs to json. {data_path}")
         sys.exit(-1)
 
     # We have to validate BEFORE we rekey

--- a/juneberry/config_loader.py
+++ b/juneberry/config_loader.py
@@ -1,46 +1,24 @@
 #! /usr/bin/env python3
 
 # ======================================================================================================================
-#  Copyright 2021 Carnegie Mellon University.
+# Juneberry - General Release
 #
-#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
-#  BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
-#  INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
-#  FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
-#  FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+# Copyright 2021 Carnegie Mellon University.
 #
-#  Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
 #
-#  [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.
-#  Please see Copyright notice for non-US Government use and distribution.
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
 #
-#  This Software includes and/or makes use of the following Third-Party Software subject to its own license:
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
 #
-#  1. PyTorch (https://github.com/pytorch/pytorch/blob/master/LICENSE) Copyright 2016 facebook, inc..
-#  2. NumPY (https://github.com/numpy/numpy/blob/master/LICENSE.txt) Copyright 2020 Numpy developers.
-#  3. Matplotlib (https://matplotlib.org/3.1.1/users/license.html) Copyright 2013 Matplotlib Development Team.
-#  4. pillow (https://github.com/python-pillow/Pillow/blob/master/LICENSE) Copyright 2020 Alex Clark and contributors.
-#  5. SKlearn (https://github.com/scikit-learn/sklearn-docbuilder/blob/master/LICENSE) Copyright 2013 scikit-learn 
-#      developers.
-#  6. torchsummary (https://github.com/TylerYep/torch-summary/blob/master/LICENSE) Copyright 2020 Tyler Yep.
-#  7. pytest (https://docs.pytest.org/en/stable/license.html) Copyright 2020 Holger Krekel and others.
-#  8. pylint (https://github.com/PyCQA/pylint/blob/main/LICENSE) Copyright 1991 Free Software Foundation, Inc..
-#  9. Python (https://docs.python.org/3/license.html#psf-license) Copyright 2001 python software foundation.
-#  10. doit (https://github.com/pydoit/doit/blob/master/LICENSE) Copyright 2014 Eduardo Naufel Schettino.
-#  11. tensorboard (https://github.com/tensorflow/tensorboard/blob/master/LICENSE) Copyright 2017 The TensorFlow 
-#                  Authors.
-#  12. pandas (https://github.com/pandas-dev/pandas/blob/master/LICENSE) Copyright 2011 AQR Capital Management, LLC,
-#             Lambda Foundry, Inc. and PyData Development Team.
-#  13. pycocotools (https://github.com/cocodataset/cocoapi/blob/master/license.txt) Copyright 2014 Piotr Dollar and
-#                  Tsung-Yi Lin.
-#  14. brambox (https://gitlab.com/EAVISE/brambox/-/blob/master/LICENSE) Copyright 2017 EAVISE.
-#  15. pyyaml  (https://github.com/yaml/pyyaml/blob/master/LICENSE) Copyright 2017 Ingy döt Net ; Kirill Simonov.
-#  16. natsort (https://github.com/SethMMorton/natsort/blob/master/LICENSE) Copyright 2020 Seth M. Morton.
-#  17. prodict  (https://github.com/ramazanpolat/prodict/blob/master/LICENSE.txt) Copyright 2018 Ramazan Polat
-#               (ramazanpolat@gmail.com).
-#  18. jsonschema (https://github.com/Julian/jsonschema/blob/main/COPYING) Copyright 2013 Julian Berman.
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
 #
-#  DM21-0689
+# DM21-0884
 #
 # ======================================================================================================================
 
@@ -189,8 +167,8 @@ def main():
     args = parser.parse_args()
     lab, errors = setup_lab({}, args.section)
 
-    logging.info(f"Loaded the config with {errors} errors.  Values:")
-    logging.info(lab)
+    logger.info(f"Loaded the config with {errors} errors.  Values:")
+    logger.info(lab)
 
 
 if __name__ == "__main__":

--- a/juneberry/detectron2/trainer.py
+++ b/juneberry/detectron2/trainer.py
@@ -311,7 +311,7 @@ class Detectron2Trainer(Trainer):
         # Establish the interval for logging the training metrics to console.
         interval = self.model_config.detectron2.metric_interval
         interval_str = "single iteration" if interval == 1 else f"{interval} iterations"
-        logging.info(f"Common training metrics will be logged after every {interval_str}.")
+        logger.info(f"Common training metrics will be logged after every {interval_str}.")
 
         # NOTE: This is copied wholesale from plain_train_net.py
         # We can do our own optimizer building, etc.

--- a/juneberry/documentation/vignettes/Replicating_a_Classic_Machine_Learning_Result_with_Juneberry.md
+++ b/juneberry/documentation/vignettes/Replicating_a_Classic_Machine_Learning_Result_with_Juneberry.md
@@ -316,10 +316,10 @@ before returning the instantiated custom model:
 class Resnet32x32:
     def __call__(self, img_width, img_height, channels, num_classes, layers):
         if img_width != 32 or img_height != 32 or channels != 3:
-            logging.error("The model only works with 32x32 RGB images.")
+            logger.error("The model only works with 32x32 RGB images.")
             sys.exit(-1)
         elif(layers - 2) % 6 != 0:
-            logging.error("Layers argument missing or incorrect. (Layers - 2) % 6 must be zero for ResNet6n2.")
+            logger.error("Layers argument missing or incorrect. (Layers - 2) % 6 must be zero for ResNet6n2.")
             sys.exit(-1)
         else:
             model = ResNetCustom(block=BB, n=int((layers - 2)/6), num_classes=num_classes)
@@ -451,10 +451,10 @@ class ResNetCustom(nn.Module):
 class Resnet32x32:
     def __call__(self, img_width, img_height, channels, num_classes, layers):
         if img_width != 32 or img_height != 32 or channels != 3:
-            logging.error("The model only works with 32x32 RGB images.")
+            logger.error("The model only works with 32x32 RGB images.")
             sys.exit(-1)
         elif (layers - 2) % 6 != 0:
-            logging.error("Layers argument missing or incorrect. (Layers - 2) % 6 must be zero for ResNet6n2.")
+            logger.error("Layers argument missing or incorrect. (Layers - 2) % 6 must be zero for ResNet6n2.")
             sys.exit(-1)
         else:
             model = ResNetCustom(block=BB, n=int((layers - 2) / 6), num_classes=num_classes)

--- a/juneberry/filesystem.py
+++ b/juneberry/filesystem.py
@@ -199,6 +199,10 @@ class ExperimentManager:
         self.experiment_name = experiment_name
         self.experiment_dir_path = Path('experiments') / self.experiment_name
         self.experiment_model_dir_path = Path('models') / self.experiment_name
+        self.experiment_log_dir_path = self.experiment_dir_path / "logs"
+
+        if not self.experiment_log_dir_path.exists():
+            self.experiment_log_dir_path.mkdir(parents=True)
 
     def get_experiment_name(self):
         """ :return: The name of the experiment. """
@@ -212,16 +216,20 @@ class ExperimentManager:
         """ :return: The path to the directory containing all of the experiment model configs. """
         return self.experiment_model_dir_path
 
+    def get_experiment_log_dir(self):
+        """ :return: The path to the directory containing some of the logs generated during the experiment. """
+        return self.experiment_log_dir_path
+
     def get_experiment_config(self):
-        """ :return: The relative path to the experiment's config file """
+        """ :return: The relative path to the experiment's config file. """
         return self.experiment_dir_path / 'config.json'
 
     def get_experiment_rules(self):
-        """ :return: The relative path to the experiment's rules file """
+        """ :return: The relative path to the experiment's rules file. """
         return self.experiment_dir_path / 'rules.json'
 
     def get_experiment_dodo(self, workflow: str):
-        """ :return: The relative path to the experiment's dodo.py pydoit file for the specified workflow"""
+        """ :return: The relative path to the experiment's dodo.py pydoit file for the specified workflow. """
         file_name = workflow + "_dodo.py"
         return self.experiment_dir_path / file_name
 
@@ -233,12 +241,12 @@ class ExperimentManager:
         return self.experiment_dir_path / file_name
 
     def get_experiment_log_path(self):
-        """ :return: The path to the experiment log file """
-        return self.experiment_dir_path / "log_experiment.txt"
+        """ :return: The path to the experiment log file. """
+        return self.experiment_log_dir_path / "log_experiment.txt"
 
     def get_experiment_dryrun_log_path(self):
-        """ :return: The path to the experiment log file """
-        return self.experiment_dir_path / "log_experiment_dryrun.txt"
+        """ :return: The path to the experiment log file. """
+        return self.experiment_log_dir_path / "log_experiment_dryrun.txt"
 
     def get_output_list(self):
         """
@@ -311,11 +319,11 @@ class AttackManager(ExperimentManager):
 
     def get_attack_setup_log(self):
         """ :return: The path to the attack setup log. """
-        return self.experiment_dir_path / 'log_attack_setup.txt'
+        return self.experiment_log_dir_path / 'log_attack_setup.txt'
 
     def get_attack_setup_dryrun_log(self):
         """ :return: The path to the dry run of the attack setup log. """
-        return self.experiment_dir_path / 'log_attack_setup_dryrun.txt'
+        return self.experiment_log_dir_path / 'log_attack_setup_dryrun.txt'
 
     def get_experiment_attack_file(self):
         """ :return: The path to the experiment's attack config file. """

--- a/juneberry/pytorch/privacy/model_transforms.py
+++ b/juneberry/pytorch/privacy/model_transforms.py
@@ -1,46 +1,24 @@
 #! /usr/bin/env python3
 
 # ======================================================================================================================
-#  Copyright 2021 Carnegie Mellon University.
+# Juneberry - General Release
 #
-#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
-#  BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
-#  INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
-#  FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
-#  FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+# Copyright 2021 Carnegie Mellon University.
 #
-#  Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
 #
-#  [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.
-#  Please see Copyright notice for non-US Government use and distribution.
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
 #
-#  This Software includes and/or makes use of the following Third-Party Software subject to its own license:
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
 #
-#  1. PyTorch (https://github.com/pytorch/pytorch/blob/master/LICENSE) Copyright 2016 facebook, inc..
-#  2. NumPY (https://github.com/numpy/numpy/blob/master/LICENSE.txt) Copyright 2020 Numpy developers.
-#  3. Matplotlib (https://matplotlib.org/3.1.1/users/license.html) Copyright 2013 Matplotlib Development Team.
-#  4. pillow (https://github.com/python-pillow/Pillow/blob/master/LICENSE) Copyright 2020 Alex Clark and contributors.
-#  5. SKlearn (https://github.com/scikit-learn/sklearn-docbuilder/blob/master/LICENSE) Copyright 2013 scikit-learn 
-#      developers.
-#  6. torchsummary (https://github.com/TylerYep/torch-summary/blob/master/LICENSE) Copyright 2020 Tyler Yep.
-#  7. pytest (https://docs.pytest.org/en/stable/license.html) Copyright 2020 Holger Krekel and others.
-#  8. pylint (https://github.com/PyCQA/pylint/blob/main/LICENSE) Copyright 1991 Free Software Foundation, Inc..
-#  9. Python (https://docs.python.org/3/license.html#psf-license) Copyright 2001 python software foundation.
-#  10. doit (https://github.com/pydoit/doit/blob/master/LICENSE) Copyright 2014 Eduardo Naufel Schettino.
-#  11. tensorboard (https://github.com/tensorflow/tensorboard/blob/master/LICENSE) Copyright 2017 The TensorFlow 
-#                  Authors.
-#  12. pandas (https://github.com/pandas-dev/pandas/blob/master/LICENSE) Copyright 2011 AQR Capital Management, LLC,
-#             Lambda Foundry, Inc. and PyData Development Team.
-#  13. pycocotools (https://github.com/cocodataset/cocoapi/blob/master/license.txt) Copyright 2014 Piotr Dollar and
-#                  Tsung-Yi Lin.
-#  14. brambox (https://gitlab.com/EAVISE/brambox/-/blob/master/LICENSE) Copyright 2017 EAVISE.
-#  15. pyyaml  (https://github.com/yaml/pyyaml/blob/master/LICENSE) Copyright 2017 Ingy döt Net ; Kirill Simonov.
-#  16. natsort (https://github.com/SethMMorton/natsort/blob/master/LICENSE) Copyright 2020 Seth M. Morton.
-#  17. prodict  (https://github.com/ramazanpolat/prodict/blob/master/LICENSE.txt) Copyright 2018 Ramazan Polat
-#               (ramazanpolat@gmail.com).
-#  18. jsonschema (https://github.com/Julian/jsonschema/blob/main/COPYING) Copyright 2013 Julian Berman.
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
 #
-#  DM21-0689
+# DM21-0884
 #
 # ======================================================================================================================
 
@@ -58,9 +36,9 @@ class ConvertBatchnormModules:
     """
 
     def __call__(self, model):
-        logging.info(f"Attempting conversion of batchnorm modules.")
+        logger.info(f"Attempting conversion of batchnorm modules.")
         model = module_modification.convert_batchnorm_modules(model)
         inspector = DPModelInspector()
-        logging.info(f"... Is converted model valid for DPSGD?: {inspector.validate(model)}")
+        logger.info(f"... Is converted model valid for DPSGD?: {inspector.validate(model)}")
 
         return model

--- a/juneberry/pytorch/processing.py
+++ b/juneberry/pytorch/processing.py
@@ -1,46 +1,24 @@
 #! /usr/bin/env python3
 
 # ======================================================================================================================
-#  Copyright 2021 Carnegie Mellon University.
+# Juneberry - General Release
 #
-#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
-#  BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
-#  INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
-#  FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
-#  FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+# Copyright 2021 Carnegie Mellon University.
 #
-#  Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
 #
-#  [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.
-#  Please see Copyright notice for non-US Government use and distribution.
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
 #
-#  This Software includes and/or makes use of the following Third-Party Software subject to its own license:
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
 #
-#  1. PyTorch (https://github.com/pytorch/pytorch/blob/master/LICENSE) Copyright 2016 facebook, inc..
-#  2. NumPY (https://github.com/numpy/numpy/blob/master/LICENSE.txt) Copyright 2020 Numpy developers.
-#  3. Matplotlib (https://matplotlib.org/3.1.1/users/license.html) Copyright 2013 Matplotlib Development Team.
-#  4. pillow (https://github.com/python-pillow/Pillow/blob/master/LICENSE) Copyright 2020 Alex Clark and contributors.
-#  5. SKlearn (https://github.com/scikit-learn/sklearn-docbuilder/blob/master/LICENSE) Copyright 2013 scikit-learn
-#      developers.
-#  6. torchsummary (https://github.com/TylerYep/torch-summary/blob/master/LICENSE) Copyright 2020 Tyler Yep.
-#  7. pytest (https://docs.pytest.org/en/stable/license.html) Copyright 2020 Holger Krekel and others.
-#  8. pylint (https://github.com/PyCQA/pylint/blob/main/LICENSE) Copyright 1991 Free Software Foundation, Inc..
-#  9. Python (https://docs.python.org/3/license.html#psf-license) Copyright 2001 python software foundation.
-#  10. doit (https://github.com/pydoit/doit/blob/master/LICENSE) Copyright 2014 Eduardo Naufel Schettino.
-#  11. tensorboard (https://github.com/tensorflow/tensorboard/blob/master/LICENSE) Copyright 2017 The TensorFlow
-#                  Authors.
-#  12. pandas (https://github.com/pandas-dev/pandas/blob/master/LICENSE) Copyright 2011 AQR Capital Management, LLC,
-#             Lambda Foundry, Inc. and PyData Development Team.
-#  13. pycocotools (https://github.com/cocodataset/cocoapi/blob/master/license.txt) Copyright 2014 Piotr Dollar and
-#                  Tsung-Yi Lin.
-#  14. brambox (https://gitlab.com/EAVISE/brambox/-/blob/master/LICENSE) Copyright 2017 EAVISE.
-#  15. pyyaml  (https://github.com/yaml/pyyaml/blob/master/LICENSE) Copyright 2017 Ingy döt Net ; Kirill Simonov.
-#  16. natsort (https://github.com/SethMMorton/natsort/blob/master/LICENSE) Copyright 2020 Seth M. Morton.
-#  17. prodict  (https://github.com/ramazanpolat/prodict/blob/master/LICENSE.txt) Copyright 2018 Ramazan Polat
-#               (ramazanpolat@gmail.com).
-#  18. jsonschema (https://github.com/Julian/jsonschema/blob/main/COPYING) Copyright 2013 Julian Berman.
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
 #
-#  DM21-0689
+# DM21-0884
 #
 # ======================================================================================================================
 
@@ -173,14 +151,14 @@ def prepare_for_distributed() -> None:
     # Set up a socket.
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-    logging.info(f"Preparing to initialize the distributed process group...")
-    logging.info(f"Checking available ports between {port} and {max_port}")
+    logger.info(f"Preparing to initialize the distributed process group...")
+    logger.info(f"Checking available ports between {port} and {max_port}")
 
     # Test ADDR:PORT combinations until an available connection is found. The first available
     # combination will be used later to initialize the distributed process group.
     while port <= max_port:
         try:
-            logging.info(f"Checking if localhost:{port} is available.")
+            logger.info(f"Checking if localhost:{port} is available.")
             s.bind(('localhost', port))
             break
 
@@ -188,17 +166,17 @@ def prepare_for_distributed() -> None:
 
             # If the address is in use, increment the port and try again.
             if e.errno == errno.EADDRINUSE:
-                logging.warning(f"localhost:{port} appears to be in use. Incrementing the port "
-                                f"and trying again.")
+                logger.warning(f"localhost:{port} appears to be in use. Incrementing the port "
+                               f"and trying again.")
                 port += 1
 
             # If some other error is encountered, print the error and exit.
             else:
-                logging.error(f"Unexpected socket error. Exiting.")
-                logging.error(f"{e}")
+                logger.error(f"Unexpected socket error. Exiting.")
+                logger.error(f"{e}")
                 sys.exit(-1)
 
-    logging.info(f"localhost:{port} appears to be available.")
+    logger.info(f"localhost:{port} appears to be available.")
 
     # Some environment variables for the process group
     os.environ['MASTER_ADDR'] = 'localhost'

--- a/juneberry/pytorch/utils.py
+++ b/juneberry/pytorch/utils.py
@@ -160,7 +160,7 @@ def save_model(model_manager: ModelManager, model, input_sample, native, onnx) -
 
     # Save the model in PyTorch format.
     if native:
-        logging.info(f"Saving PyTorch model file to {model_manager.get_pytorch_model_path()}")
+        logger.info(f"Saving PyTorch model file to {model_manager.get_pytorch_model_path()}")
         model_path = model_manager.get_pytorch_model_path()
         torch.save(model.state_dict(), model_path)
 
@@ -168,7 +168,7 @@ def save_model(model_manager: ModelManager, model, input_sample, native, onnx) -
     # LIMITATION: If the model is dynamic, e.g., changes behavior depending on input data, the
     # ONNX export won't be accurate. This is because the ONNX exporter is a trace-based exporter.
     if onnx:
-        logging.info(f"Saving ONNX model file to {model_manager.get_onnx_model_path()}")
+        logger.info(f"Saving ONNX model file to {model_manager.get_onnx_model_path()}")
         torch.onnx.export(model, input_sample, model_manager.get_onnx_model_path(), export_params=True)
 
 

--- a/juneberry/scripting.py
+++ b/juneberry/scripting.py
@@ -136,7 +136,7 @@ def setup_workspace(args, *, log_file, log_prefix="", add_data_root=True, model_
     return lab
 
 
-def setup_logging_for_script(args, script_name: str):
+def setup_logging_for_script(args, script_name: str = None):
     """
     This function is responsible for setting up logging in a Juneberry script. This function is typically used when
     the root juneberry logger cannot be set up by other means.
@@ -148,6 +148,8 @@ def setup_logging_for_script(args, script_name: str):
     """
     # Build the location of the log using the desired log directory (from args) and the name of
     # the script calling this function.
+    if script_name is None:
+        script_name = Path(sys.argv[0]).stem
     log_file = Path(args.logDir) / f"log_{script_name}.txt"
 
     # Set the logging level and setup the logger.
@@ -155,7 +157,8 @@ def setup_logging_for_script(args, script_name: str):
     jblogging.setup_logger(log_file, log_prefix="", log_to_console=not args.silent, level=level)
 
     # A simple test message indicating where the log messages are being saved to.
-    logger.info(f"Log messages for {script_name} are beings saved to {log_file}")
+    logger.info(f"Logging initialized for {Path(sys.argv[0]).absolute()}")
+    logger.info(f"Log messages are beings saved to {log_file}")
 
 
 def setup_for_single_model(args, *, log_file, model_name, log_prefix="", add_data_root=True, banner_msg=None) -> Lab:

--- a/juneberry/scripting.py
+++ b/juneberry/scripting.py
@@ -67,6 +67,8 @@ def setup_args(parser, add_data_root=True) -> None:
                         help='Silent flag to silence output to console. Default is to show to console.')
     parser.add_argument('-v', '--verbose', default=False, action='store_true',
                         help='Verbose flag that will log DEBUG messages. Default is off.')
+    parser.add_argument('-l', '--logDir', default=Path.cwd(), required=False,
+                        help="Directory where the log file will be saved. Default is the current working directory.")
 
 
 def setup_workspace(args, *, log_file, log_prefix="", add_data_root=True, model_name=None, name="juneberry",
@@ -128,6 +130,28 @@ def setup_workspace(args, *, log_file, log_prefix="", add_data_root=True, model_
         logger.info(f"Default data_root: {lab.data_root()}")
 
     return lab
+
+
+def setup_logging_for_script(args, script_name: str):
+    """
+    This function is responsible for setting up logging in a Juneberry script. This function is typically used when
+    the root juneberry logger cannot be set up by other means.
+    :param args: The args from parseargs.
+    :param script_name: A string indicating which script the log messages are from. Used to build
+    the name of the log file.
+    :return: Nothing.
+
+    """
+    # Build the location of the log using the desired log directory (from args) and the name of
+    # the script calling this function.
+    log_file = Path(args.logDir) / f"log_{script_name}.txt"
+
+    # Set the logging level and setup the logger.
+    level = logging.DEBUG if args.verbose else logging.INFO
+    jblogging.setup_logger(log_file, log_prefix="", log_to_console=not args.silent, level=level)
+
+    # A simple test message indicating where the log messages are being saved to.
+    logger.info(f"Log messages for {script_name} are beings saved to {log_file}")
 
 
 def setup_for_single_model(args, *, log_file, model_name, log_prefix="", add_data_root=True, banner_msg=None) -> Lab:

--- a/juneberry/tensorflow/callbacks.py
+++ b/juneberry/tensorflow/callbacks.py
@@ -102,16 +102,16 @@ class TimingCallback(tf.keras.callbacks.Callback):
 
         self.last_report_time = report_time
 
-        logging.info(f"{epoch + 1}/{self.total_epochs} "
-                     f"time: {train_elapsed:.2f}s "
-                     f"eta: {eta.strftime('%H:%M:%S')} "
-                     f"images/s: {self.num_images / train_elapsed:.2f} "
-                     f"-- "
-                     f"loss: {logs['loss']:.4f} "
-                     f"acc: {logs['accuracy']:.4f} "
-                     f"val_loss: {logs['val_loss']:.4f} "
-                     f"val_acc: {logs['val_accuracy']:.4f} "
-                     )
+        logger.info(f"{epoch + 1}/{self.total_epochs} "
+                    f"time: {train_elapsed:.2f}s "
+                    f"eta: {eta.strftime('%H:%M:%S')} "
+                    f"images/s: {self.num_images / train_elapsed:.2f} "
+                    f"-- "
+                    f"loss: {logs['loss']:.4f} "
+                    f"acc: {logs['accuracy']:.4f} "
+                    f"val_loss: {logs['val_loss']:.4f} "
+                    f"val_acc: {logs['val_accuracy']:.4f} "
+                    )
 
 
 class TrainingMetricsCallback(tf.keras.callbacks.Callback):

--- a/juneberry/tensorflow/trainer.py
+++ b/juneberry/tensorflow/trainer.py
@@ -140,10 +140,10 @@ class ClassifierTrainer(juneberry.trainer.Trainer):
         # Set up tensorboard
         if self.lab.tensorboard:
             log_dir = self.model_manager.create_tensorboard_directory_name(self.lab.tensorboard)
-            logging.info(f"Setting up TensorBoard for directory {log_dir}")
+            logger.info(f"Setting up TensorBoard for directory {log_dir}")
             self.callbacks.append(tf.keras.callbacks.TensorBoard(log_dir=log_dir, histogram_freq=1))
         else:
-            logging.info(f"TensorBoard NOT configured.")
+            logger.info(f"TensorBoard NOT configured.")
 
         # Setup other instrumentation and callbacks - MUST happen after the model is constructed
         self.setup_callbacks()
@@ -318,7 +318,7 @@ class ClassifierTrainer(juneberry.trainer.Trainer):
                 sys.exit(-1)
 
     def compile_model(self):
-        logging.info("Compiling the model")
+        logger.info("Compiling the model")
         if self.loss_fn is None or self.optimizer is None:
             logger.error("Cannot compile a model without an optimizer and loss function. EXITING.")
             sys.exit(-1)

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -115,8 +115,8 @@ def test_experiment_manager():
     assert em.get_experiment_name() == "millikan_oil_drop"
     assert em._get_experiment_dir() == root
     assert em.get_experiment_config() == root / 'config.json'
-    assert em.get_experiment_log_path() == root / "log_experiment.txt"
-    assert em.get_experiment_dryrun_log_path() == root / "log_experiment_dryrun.txt"
+    assert em.get_experiment_log_path() == root / "logs" / "log_experiment.txt"
+    assert em.get_experiment_dryrun_log_path() == root / "logs" / "log_experiment_dryrun.txt"
 
 
 def test_experiment_manager_clean():


### PR DESCRIPTION
Lots of logging changes here. The starting point is probably in `juneberry/scripting.py`. You'll see that a new arg has been added for setting a directory where the log file will be saved, with a default of the current working directory. 

Once that was in place, the next area to look would be the new function in `scripting.py` which was built to take advantage of that new arg. Basically any script can use this function to set up the root juneberry logger and dump a log file to the desired log directory. Scripts where logging was already set up the way we wanted weren't updated to use this new function, but most of the other scripts were.

The last major change to point out would be a new `logs` subdirectory that gets created inside of an experiments directory. The overall experiment logs should start showing up in this `logs` directory now, and any script logs (for things like summary reports, etc.) will also be placed here if they're associated with the experiment.