### PR TITLE
DT2 Warning Investigation

### DIFF
--- a/juneberry/detectron2/trainer.py
+++ b/juneberry/detectron2/trainer.py
@@ -157,8 +157,9 @@ class Detectron2Trainer(Trainer):
         dt2_data.register_train_manifest_files(self.lab, self.model_manager)
 
         # =======
-
-        logger.warning("We do NOT support model transforms!!!")
+        if self.model_config.model_transforms is not None:
+            logger.warning(f"The model config contains model transforms, however the detectron2 trainer does not "
+                           f"currently support model transforms. Ignoring the requested model transforms.")
 
         # Get a basic config
         cfg = get_cfg()
@@ -311,7 +312,7 @@ class Detectron2Trainer(Trainer):
         # Establish the interval for logging the training metrics to console.
         interval = self.model_config.detectron2.metric_interval
         interval_str = "single iteration" if interval == 1 else f"{interval} iterations"
-        logging.info(f"Common training metrics will be logged after every {interval_str}.")
+        logger.info(f"Common training metrics will be logged after every {interval_str}.")
 
         # NOTE: This is copied wholesale from plain_train_net.py
         # We can do our own optimizer building, etc.

--- a/juneberry/documentation/known_warnings.md
+++ b/juneberry/documentation/known_warnings.md
@@ -1,0 +1,101 @@
+Known Warnings in Juneberry
+============
+
+# Overview
+
+This file documents known warning messages you may encounter when using Juneberry. Each section should 
+contain some example text of the warning that you may see in a log file, along with a possible explanation 
+for what's causing the issue. Not all warnings necessarily represent something that must be corrected.
+
+## The System Test
+
+### Detectron2
+
+#### Number of workers in ModelConfig
+
+##### Message
+```
+WARNING Overriding number of workers. Found 1 in ModelConfig
+```
+
+##### Response
+This warning is due to the presence of the `num_workers` key in the "hints" stanza of the 
+text_detect/dt2/ut model config.json. The warning exists to indicate when the number of worker
+processes is set to a value. Since the stanza in the model config requests one worker process, 
+the warning message is triggered when the number of workers gets set to 1.
+
+#### Category IDs in annotations
+
+##### Message
+```
+WARNING (detectron2.data.datasets.coco:92): 
+Category ids in annotations are not in [1, #categories]! We'll apply a mapping for you.
+```
+
+##### Response
+Detectron2 expects COCO format metadata annotations to have IDs that start at 1 and remain 
+contiguous until the full range of classes is represented. When these conditions aren't met, 
+detectron2 applies a mapping which converts between the ID values that were provided, and the 
+converted values that detectron2 expects. In the case of the text_detect dataset used by the 
+system test, you can see from the dataset config file that the provided label IDs in the dataset 
+are 0, 1, 2, thus violating the range that detectron2 expects. Therefore, a mapping will be applied 
+whenever this dataset is used by detectron2.
+
+#### Skip loading parameter
+
+##### Message(s)
+```
+WARNING (fvcore.common.checkpoint:338): Skip loading parameter 
+'roi_heads.box_predictor.cls_score.weight' to the model due to incompatible shapes: (81, 1024) 
+in the checkpoint but (4, 1024) in the model! You might want to double check if this is expected.
+
+WARNING (fvcore.common.checkpoint:338): Skip loading parameter 
+'roi_heads.box_predictor.cls_score.bias' to the model due to incompatible shapes: (81,) 
+in the checkpoint but (4,) in the model! You might want to double check if this is expected.
+
+WARNING (fvcore.common.checkpoint:338): Skip loading parameter 
+'roi_heads.box_predictor.bbox_pred.weight' to the model due to incompatible shapes: (320, 1024) 
+in the checkpoint but (12, 1024) in the model! You might want to double check if this is expected.
+
+WARNING (fvcore.common.checkpoint:338): Skip loading parameter 
+'roi_heads.box_predictor.bbox_pred.bias' to the model due to incompatible shapes: (320,) 
+in the checkpoint but (12,) in the model! You might want to double check if this is expected.
+```
+
+##### Response
+https://github.com/facebookresearch/detectron2/issues/196 suggests this behavior is expected 
+because the number of classes in the dataset differs from the number of classes from the pre-trained 
+model. 
+
+#### Model parameters or buffers not found in checkpoint
+
+##### Message
+
+```
+WARNING (fvcore.common.checkpoint:350): Some model parameters or buffers are not found in the checkpoint:
+roi_heads.box_predictor.bbox_pred.{bias, weight}
+roi_heads.box_predictor.cls_score.{bias, weight}
+```
+
+##### Response
+https://github.com/facebookresearch/detectron2/issues/803 suggests this warning occurs because 
+the ImageNet pre-trained model being used to conduct the system test does not have model parameters 
+for this detection model. Therefore, this warning message is expected, and probably safe to ignore. 
+Furthermore, due to warning messages shown in the "Skip loading parameter" section, you can see there's 
+a relationship between the model parameters mentioned here that were not found in the checkpoint, and the 
+model parameters from the earlier warnings whose loading was skipped due to incompatible shapes.
+
+#### Checkpoint contains keys that are not used by the model
+
+##### Message
+
+```
+WARNING (fvcore.common.checkpoint:352): The checkpoint state_dict contains keys that are not 
+used by the model:
+  proposal_generator.anchor_generator.cell_anchors.{0, 1, 2, 3, 4}
+```
+
+##### Response
+https://github.com/facebookresearch/detectron2/issues/803 suggests this warning occurs because 
+the ImageNet pre-trained model being used to conduct the system test does not have model parameters 
+for this detection model. Therefore, this warning message is expected, and probably safe to ignore.

--- a/models/text_detect/dt2/ut/config.json
+++ b/models/text_detect/dt2/ut/config.json
@@ -11,6 +11,9 @@
     },
     "epochs": 1,
     "evaluation_transforms": [],
+    "evaluator": {
+        "fqcn": "juneberry.detectron2.evaluator.Evaluator"
+    },
     "format_version": "0.2.0",
     "hints": {
         "num_workers": 1
@@ -28,6 +31,9 @@
     "seed": 4210592948,
     "task": "objectDetection",
     "timestamp": "2021-03-03T10:00:00",
+    "trainer": {
+        "fqcn": "juneberry.detectron2.trainer.Detectron2Trainer"
+    },
     "training_dataset_config_path": "data_sets/text_detect_val.json",
     "training_transforms": [],
     "validation": {

--- a/scripts/run_all_tests.py
+++ b/scripts/run_all_tests.py
@@ -1,46 +1,24 @@
 #! /usr/bin/env python3
 
 # ======================================================================================================================
-#  Copyright 2021 Carnegie Mellon University.
+# Juneberry - General Release
 #
-#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
-#  BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
-#  INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
-#  FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
-#  FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+# Copyright 2021 Carnegie Mellon University.
 #
-#  Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
 #
-#  [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.
-#  Please see Copyright notice for non-US Government use and distribution.
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
 #
-#  This Software includes and/or makes use of the following Third-Party Software subject to its own license:
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
 #
-#  1. PyTorch (https://github.com/pytorch/pytorch/blob/master/LICENSE) Copyright 2016 facebook, inc..
-#  2. NumPY (https://github.com/numpy/numpy/blob/master/LICENSE.txt) Copyright 2020 Numpy developers.
-#  3. Matplotlib (https://matplotlib.org/3.1.1/users/license.html) Copyright 2013 Matplotlib Development Team.
-#  4. pillow (https://github.com/python-pillow/Pillow/blob/master/LICENSE) Copyright 2020 Alex Clark and contributors.
-#  5. SKlearn (https://github.com/scikit-learn/sklearn-docbuilder/blob/master/LICENSE) Copyright 2013 scikit-learn 
-#      developers.
-#  6. torchsummary (https://github.com/TylerYep/torch-summary/blob/master/LICENSE) Copyright 2020 Tyler Yep.
-#  7. pytest (https://docs.pytest.org/en/stable/license.html) Copyright 2020 Holger Krekel and others.
-#  8. pylint (https://github.com/PyCQA/pylint/blob/main/LICENSE) Copyright 1991 Free Software Foundation, Inc..
-#  9. Python (https://docs.python.org/3/license.html#psf-license) Copyright 2001 python software foundation.
-#  10. doit (https://github.com/pydoit/doit/blob/master/LICENSE) Copyright 2014 Eduardo Naufel Schettino.
-#  11. tensorboard (https://github.com/tensorflow/tensorboard/blob/master/LICENSE) Copyright 2017 The TensorFlow 
-#                  Authors.
-#  12. pandas (https://github.com/pandas-dev/pandas/blob/master/LICENSE) Copyright 2011 AQR Capital Management, LLC,
-#             Lambda Foundry, Inc. and PyData Development Team.
-#  13. pycocotools (https://github.com/cocodataset/cocoapi/blob/master/license.txt) Copyright 2014 Piotr Dollar and
-#                  Tsung-Yi Lin.
-#  14. brambox (https://gitlab.com/EAVISE/brambox/-/blob/master/LICENSE) Copyright 2017 EAVISE.
-#  15. pyyaml  (https://github.com/yaml/pyyaml/blob/master/LICENSE) Copyright 2017 Ingy döt Net ; Kirill Simonov.
-#  16. natsort (https://github.com/SethMMorton/natsort/blob/master/LICENSE) Copyright 2020 Seth M. Morton.
-#  17. prodict  (https://github.com/ramazanpolat/prodict/blob/master/LICENSE.txt) Copyright 2018 Ramazan Polat
-#               (ramazanpolat@gmail.com).
-#  18. jsonschema (https://github.com/Julian/jsonschema/blob/main/COPYING) Copyright 2013 Julian Berman.
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
 #
-#  DM21-0689
+# DM21-0884
 #
 # ======================================================================================================================
 
@@ -71,7 +49,7 @@ def main():
     # We want to test the stuff we are part of, not something in the path.
     juneberry_dir = Path(__file__).resolve().parent.parent
 
-    tests = [['pytest', str(juneberry_dir / 'test')],
+    tests = [['pytest', str(juneberry_dir / 'test'), '-W ignore::DeprecationWarning'],
              ['python3', str(juneberry_dir / 'scripts/run_system_test.py'), '--initifneeded']
              ]
 


### PR DESCRIPTION
Corrected a few things while investigating warnings/error messages logged during detectron2 training and evaluation. The most notable additions to this PR are the start of some documentation for what warning message we have observed and expect, and a change to the system test that suppresses any DeprecationWarnings, which were pretty much all of the warning messages we were seeing in the PyTest portion of the system test.