### PR TITLE
Fix for experiments where a model is evaluated by multiple datasets

### DIFF
--- a/bin/jb_experiment_to_rules
+++ b/bin/jb_experiment_to_rules
@@ -119,7 +119,7 @@ class RuleMaker:
             if model.tests:
                 for test in model.tests:
                     inputs = [model_mgr.get_model_path(), test.dataset_path]
-                    outputs = model_mgr.get_predictions_output_list(test.dataset_path)
+                    outputs = model_mgr.get_evaluation_output_list(test.dataset_path)
                     command = [JB_EVALUATE_COMMAND, model_mgr.model_name, test.dataset_path]
                     if test.classify:
                         command.extend(["--topK", test.classify])
@@ -139,7 +139,8 @@ class RuleMaker:
                         'dataset': test.dataset_path,
                         'filename': eval_dir_mgr.get_predictions_path(),
                         'id': cmd_id,
-                        'model': model.name
+                        'model': model.name,
+                        'metrics': eval_dir_mgr.get_metrics_path()
                     }
 
                     if test.filters:
@@ -172,9 +173,9 @@ class RuleMaker:
         # Add all tests to the command.
         for test in report.tests:
 
-            # The presence of this prediction file indicates an evaluation has occurred for this
-            # model / dataset combination. The plot_pr script relies on the data in the predictions file.
-            predictions_file = str(self.tag_map[test.tag]['filename'])
+            # The presence of the metrics file indicates an evaluation has occurred for this
+            # model / dataset combination.
+            predictions_file = str(self.tag_map[test.tag]['metrics'])
             inputs.append(predictions_file)
 
             # Add the model and eval dataset arguments to the command.
@@ -247,8 +248,8 @@ class RuleMaker:
 
         for entry in self.tag_map.values():
             command.append('-f')
-            command.append(entry['filename'])
-            inputs.append(entry['filename'])
+            command.append(entry['metrics'])
+            inputs.append(entry['metrics'])
             requirements.append(entry['id'])
 
         # We need all the output file names. Depending on the report type, different plots may

--- a/bin/jb_run_experiment
+++ b/bin/jb_run_experiment
@@ -92,11 +92,13 @@ def main():
                                                  "a series of outputs into the experimentName directory. NOTE: By "
                                                  "default this script reports what it WOULD do but does not perform "
                                                  "any action. See --commit. NOTE: This script executes other scripts "
-                                                 "in the same directory.")
+                                                 "in the same directory. ARGS NOTE: Any command line args that are not "
+                                                 "recognized as positional or optional args for jb_run_experiment will "
+                                                 "be passed to the pydoit command.")
 
     setup_args(parser)
     jbscripting.setup_args(parser, add_data_root=True)
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
     show_command = args.showcmd
 
     # Set up logging
@@ -172,11 +174,7 @@ def main():
         cmd_args = [bin_dir / "jb_rules_to_pydoit", args.experimentName, workflow]
         if args.processes and args.processes > 0:
             cmd_args.append('--parallel')
-        jbworkflow.run_command(
-            dependencies=[],
-            args=cmd_args,
-            show_command=show_command,
-        )
+        jbworkflow.run_command(dependencies=[], args=cmd_args, show_command=show_command)
 
     # Develop pydoit command
     cmd_args = ["python", "-m", "doit", "-d", str(lab.workspace()), "-f", str(dodo_path.resolve())]
@@ -206,6 +204,18 @@ def main():
             logger.info("R: run, U: up-to-date, I: ignored")
             cmd_args.append("list")
             cmd_args.append("-s")
+
+    # Save the db file for pydoit to the experiment directory.
+    db_path = str(experiment_manager.get_experiment_db_file())
+    cmd_args.extend(['--db-file', db_path])
+
+    # If there were any args that jb_run_experiment didn't recognize, log them and add them
+    # to the pydoit command.
+    if unknown:
+        logger.warning(f"jb_run_experiment did not recognize the following args: {unknown}")
+        logger.warning(f"Attempting to pass these arg(s) to the pydoit command.")
+        for arg in unknown:
+            cmd_args.append(arg)
 
     # Run PyDoit command
     jbworkflow.run_command(dependencies=[], args=cmd_args, show_command=show_command)

--- a/bin/jb_train
+++ b/bin/jb_train
@@ -163,7 +163,7 @@ def main():
     trainer = jb_loader.construct_instance(fqcn, kw_args, opt_args)
 
     if trainer is None:
-        logger.error("No Trainer instantiated for configuration.  Exiting.")
+        logger.error("No Trainer instantiated for configuration. Exiting.")
         sys.exit(-1)
 
     # Set the output format for the trainer.

--- a/juneberry/detectron2/evaluator.py
+++ b/juneberry/detectron2/evaluator.py
@@ -215,5 +215,5 @@ class Evaluator(EvaluatorBase):
         coco_utils.generate_bbox_images(out, self.lab, sample_dir, sample_limit=20, shuffle=True)
 
         # Save the eval output to file.
-        logger.info(f"Saving evaluation output to {self.eval_dir_mgr.get_predictions_path()}")
-        self.output_builder.save_predictions(self.eval_dir_mgr.get_predictions_path())
+        logger.info(f"Saving evaluation output to {self.eval_dir_mgr.get_metrics_path()}")
+        self.output_builder.save_predictions(self.eval_dir_mgr.get_metrics_path())

--- a/juneberry/filesystem.py
+++ b/juneberry/filesystem.py
@@ -803,8 +803,7 @@ class ModelManager:
             eval_dir_mgr.root,
             eval_dir_mgr.get_predictions_path(),
             eval_dir_mgr.get_log_path(),
-            eval_dir_mgr.get_metrics_path(),
-            eval_dir_mgr.root.parent,
+            eval_dir_mgr.get_metrics_path()
         ]
 
     @staticmethod

--- a/juneberry/mmdetection/evaluator.py
+++ b/juneberry/mmdetection/evaluator.py
@@ -262,7 +262,7 @@ class Evaluator(EvaluatorBase):
 
         populate_metrics(self.model_manager, self.eval_dir_mgr, self.output)
 
-        self.output_builder.save_predictions(self.eval_dir_mgr.get_predictions_path())
+        self.output_builder.save_predictions(self.eval_dir_mgr.get_metrics_path())
 
         # TODO: Add some samples. Refactor the code out of DT2.
 

--- a/scripts/run_system_test.py
+++ b/scripts/run_system_test.py
@@ -264,9 +264,9 @@ def check_training_metric(model_name, model_mgr, eval_dir_mgr, min_train_metric,
 
     train_outfile = model_mgr.get_training_out_file()
     training_data = TrainingOutput.load(train_outfile)
-    if model_mgr.model_task is "classification":
+    if model_mgr.model_task == "classification":
         eval_data = EvaluationOutput.load(eval_dir_mgr.get_predictions_path())
-    elif model_mgr.model_task is "objectDetection":
+    elif model_mgr.model_task == "objectDetection":
         eval_data = EvaluationOutput.load(eval_dir_mgr.get_metrics_path())
     else:
         logging.error(f"Unknown task type detected for model {model_name}. Unable to determine which training metric "
@@ -659,9 +659,9 @@ def check_metric(test_set) -> int:
     for model_name, test_name, min_train_metric, min_eval_metric in test_set:
         model_mgr = jbfs.ModelManager(model_name)
         eval_dir_mgr = model_mgr.get_eval_dir_mgr(test_name)
-        if model_mgr.model_task is "classification":
+        if model_mgr.model_task == "classification":
             metric_file_path = eval_dir_mgr.get_predictions_path()
-        elif model_mgr.model_task is "objectDetection":
+        elif model_mgr.model_task == "objectDetection":
             metric_file_path = eval_dir_mgr.get_metrics_path()
         else:
             logging.warning(f"The task type for model '{model_name}' could not be determined. Skipping metrics check.")

--- a/scripts/run_system_test.py
+++ b/scripts/run_system_test.py
@@ -264,7 +264,14 @@ def check_training_metric(model_name, model_mgr, eval_dir_mgr, min_train_metric,
 
     train_outfile = model_mgr.get_training_out_file()
     training_data = TrainingOutput.load(train_outfile)
-    eval_data = EvaluationOutput.load(eval_dir_mgr.get_predictions_path())
+    if model_mgr.model_task is "classification":
+        eval_data = EvaluationOutput.load(eval_dir_mgr.get_predictions_path())
+    elif model_mgr.model_task is "objectDetection":
+        eval_data = EvaluationOutput.load(eval_dir_mgr.get_metrics_path())
+    else:
+        logging.error(f"Unknown task type detected for model {model_name}. Unable to determine which training metric "
+                      f"to check for this model. Exiting.")
+        sys.exit(-1)
 
     platform = model_mgr.get_model_platform()
 
@@ -284,7 +291,7 @@ def check_training_metric(model_name, model_mgr, eval_dir_mgr, min_train_metric,
         eval_metric = eval_data.results.metrics.accuracy
 
     else:
-        logging.error(f"Unknown platform type detected for model {model_name}. EXITING.")
+        logging.error(f"Unknown platform type detected for model {model_name}. Exiting.")
         sys.exit(-1)
 
     if training_metric >= min_train_metric:
@@ -652,12 +659,18 @@ def check_metric(test_set) -> int:
     for model_name, test_name, min_train_metric, min_eval_metric in test_set:
         model_mgr = jbfs.ModelManager(model_name)
         eval_dir_mgr = model_mgr.get_eval_dir_mgr(test_name)
-        prediction_file_path = eval_dir_mgr.get_predictions_path()
+        if model_mgr.model_task is "classification":
+            metric_file_path = eval_dir_mgr.get_predictions_path()
+        elif model_mgr.model_task is "objectDetection":
+            metric_file_path = eval_dir_mgr.get_metrics_path()
+        else:
+            logging.warning(f"The task type for model '{model_name}' could not be determined. Skipping metrics check.")
+            continue
 
         # Check the metric against what we expect before we move forward
         # If good, make a latest results file that can be checked
         if check_training_metric(model_name, model_mgr, eval_dir_mgr, min_train_metric, min_eval_metric):
-            convert_output_to_latest(model_mgr, prediction_file_path)
+            convert_output_to_latest(model_mgr, metric_file_path)
         else:
             failures += 1
 


### PR DESCRIPTION
If you have an experiment where you have a trained model, and then you want to evaluate that model multiple times using different datasets, pydoit will complain because the parent eval directory `models/model_name/eval` will always appear in the list of targets (output files) that should get created).

The fix is to simply remove that target from the list of files. That check was redundant anyway, because the first target that gets added to the list is the "root" eval directory `models/model_name/eval/eval_dataset_name`. Since the check for this target will remain, if it exists then this implies that `models/model_name/eval` must also exist.