### PR TITLE
JB391- Pytorch eval classifier now saves the eval manifest.

### DIFF
--- a/juneberry/data.py
+++ b/juneberry/data.py
@@ -58,13 +58,13 @@ def dataspec_to_manifests(lab: Lab, dataset_config, *,
                           splitting_config: SplittingConfig = SplittingConfig(None, None, None),
                           preprocessors: TransformManager = None):
     """
-    Creates the appropriate data loaders based on the training and dataset configurations.
+    Creates the appropriate data manifests (file path/label) based on the training and dataset configurations.
     :param lab: The Juneberry Lab in which this operation occurs.
     :param dataset_config: The dataset config that describes the data.
     :param splitting_config: OPTIONAL The SplittingConfig that is used to split the data into
     a separate subset. Specify None for no splitting.
     :param preprocessors: OPTIONAL - A TransformManager to be applied to each entry before returning.
-    :return: This function returns data_loader, split_loader
+    :return: This function returns data manifest and validation manifest
     """
     # In case folks pass in None for the config
     if splitting_config is None:
@@ -233,7 +233,7 @@ def make_eval_manifest_file(lab: Lab, dataset_config: DatasetConfig,
 
 class DatasetMarshal:
     """
-    Dataset Marshalls are used to load and process various types of data configs into "datasets"
+    Dataset Marshals are used to load and process various types of data configs into "datasets"
     that are basically lists of data items (pytorch Datasets that support __len__ and __getitem__)
     that can be fed to data loaders.
     """

--- a/juneberry/pytorch/evaluation/evaluator.py
+++ b/juneberry/pytorch/evaluation/evaluator.py
@@ -181,13 +181,20 @@ class Evaluator(EvaluatorBase):
                 logger.info("Evaluating using ONLY the validation portion of the split data.")
                 eval_list = split
 
+
             # The eval list is the already a list of name and targets
             self.eval_name_targets = eval_list
 
+            # NOTE: In the process of making the data loader we shuffle the data.
             self.eval_loader = pyt_data.make_eval_data_loader(self.lab,
                                                               self.eval_dataset_config,
                                                               self.model_config,
                                                               eval_list)
+
+            # Save the manifest
+            jbdata.save_path_label_manifest(eval_list,
+                                            self.eval_dir_mgr.get_manifest_path(),
+                                            self.lab.data_root())
 
         logger.info(f"EVALUATION dataloader created.")
         logger.info(f"There are {len(self.eval_name_targets)} pieces of data in the evaluation list.")

--- a/juneberry/pytorch/evaluation/evaluator.py
+++ b/juneberry/pytorch/evaluation/evaluator.py
@@ -181,7 +181,6 @@ class Evaluator(EvaluatorBase):
                 logger.info("Evaluating using ONLY the validation portion of the split data.")
                 eval_list = split
 
-
             # The eval list is the already a list of name and targets
             self.eval_name_targets = eval_list
 
@@ -192,9 +191,10 @@ class Evaluator(EvaluatorBase):
                                                               eval_list)
 
             # Save the manifest
-            jbdata.save_path_label_manifest(eval_list,
-                                            self.eval_dir_mgr.get_manifest_path(),
-                                            self.lab.data_root())
+            if self.eval_dataset_config.is_image_type():
+                jbdata.save_path_label_manifest(eval_list,
+                                                self.eval_dir_mgr.get_manifest_path(),
+                                                self.lab.data_root())
 
         logger.info(f"EVALUATION dataloader created.")
         logger.info(f"There are {len(self.eval_name_targets)} pieces of data in the evaluation list.")

--- a/scripts/reformat_predictions.py
+++ b/scripts/reformat_predictions.py
@@ -1,0 +1,91 @@
+#! /usr/bin/env python3
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# ======================================================================================================================
+# Juneberry - General Release
+#
+# Copyright 2021 Carnegie Mellon University.
+#
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+#
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
+#
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
+#
+# DM21-0884
+#
+# ======================================================================================================================
+
+
+def reformat_data(manifest, pred):
+    # The manifest and predictions are in the same order, so just numerically
+    # walk the number of images and spew out a new structure.
+    new_pred = []
+
+    pred_labels = pred['results']['labels']
+    pred_preds = pred['results']['predictions']
+
+    for idx, item in enumerate(manifest):
+        # Double check the label
+        assert item['label'] == pred_labels[idx]
+
+        # Make a new entry
+        new_pred.append({
+            "path": item['path'],
+            "label": item['label'],
+            "predictions": pred_preds[idx]
+        })
+
+    # Replace it int the predictions structure and return
+    new_out = pred.copy()
+    del new_out['results']['labels']
+    new_out['results']['predictions'] = new_pred
+
+    return new_out
+
+
+def reformat_file(eval_dir: str):
+    manifest_path = Path(eval_dir) / "eval_manifest.json"
+    pred_path = Path(eval_dir) / "predictions.json"
+    out_path = Path(eval_dir) / "predictions_v2.json"
+
+    if not manifest_path.exists():
+        print(f"Missing '{manifest_path}' file. Exiting")
+        sys.exit()
+
+    if not pred_path.exists():
+        print(f"Missing '{pred_path}' file. Exiting")
+        sys.exit()
+
+    with open(pred_path) as pred_file:
+        pred_data = json.load(pred_file)
+
+    with open(manifest_path) as manifest_file:
+        manifest_data = json.load(manifest_file)
+
+    out_data = reformat_data(manifest_data, pred_data)
+
+    with open(out_path, "w") as out_file:
+        json.dump(out_data, out_file, indent=4)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("eval_dir", help="Path to directory with predictions and manifest.")
+    args = parser.parse_args()
+    reformat_file(args.eval_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reformat_predictions.py
+++ b/scripts/reformat_predictions.py
@@ -1,10 +1,5 @@
 #! /usr/bin/env python3
 
-import argparse
-import json
-import sys
-from pathlib import Path
-
 # ======================================================================================================================
 # Juneberry - General Release
 #
@@ -27,6 +22,11 @@ from pathlib import Path
 #
 # ======================================================================================================================
 
+import argparse
+import json
+import sys
+from pathlib import Path
+
 
 def reformat_data(manifest, pred):
     # The manifest and predictions are in the same order, so just numerically
@@ -47,7 +47,7 @@ def reformat_data(manifest, pred):
             "predictions": pred_preds[idx]
         })
 
-    # Replace it int the predictions structure and return
+    # Replace it in the predictions structure and return
     new_out = pred.copy()
     del new_out['results']['labels']
     new_out['results']['predictions'] = new_pred
@@ -61,11 +61,11 @@ def reformat_file(eval_dir: str):
     out_path = Path(eval_dir) / "predictions_v2.json"
 
     if not manifest_path.exists():
-        print(f"Missing '{manifest_path}' file. Exiting")
+        print(f"Missing '{manifest_path}' file. Exiting.")
         sys.exit()
 
     if not pred_path.exists():
-        print(f"Missing '{pred_path}' file. Exiting")
+        print(f"Missing '{pred_path}' file. Exiting.")
         sys.exit()
 
     with open(pred_path) as pred_file:


### PR DESCRIPTION
Also, a simple utility to make a v2 predictions file.

To test, re-run the eval for imagenette-160 and see the manifest file.  For the script do 

./scripts/reformat-predictions.py models/imagenette_160x160_rgb_unit_test_pyt_resnet18/eval/imagenette_unit_test

And see a new predictions_v2.json file with a combined format.