### PR TITLE
Feature/jb 398 transforms change labels

### DIFF
--- a/docs/specs/model_configuration_specification.md
+++ b/docs/specs/model_configuration_specification.md
@@ -285,7 +285,7 @@ Each transform is an instance of a class that has a `__call__` method which acce
 image or tensor (with optional args) and an optional `__init__` method that accepts an 
 optional set of arguments. 
 The values to the `__call__` method are those that change on a per data element basis.
-The values to the `__init__` method come from an optional kwargs stanza in a condig.
+The values to the `__init__` method come from an optional kwargs stanza in a config.
 The plugin should follow the following structure:
 
 ```

--- a/juneberry/data.py
+++ b/juneberry/data.py
@@ -47,7 +47,7 @@ from juneberry.config.training_output import TrainingOutput
 import juneberry.filesystem as jbfs
 from juneberry.filesystem import ModelManager
 from juneberry.lab import Lab
-from juneberry.transform_manager import TransformManager
+from juneberry.transform_manager import TransformManager, LabeledTransformManager
 
 logger = logging.getLogger(__name__)
 
@@ -1271,7 +1271,7 @@ def load_path_label_manifest(filename, relative_to: Path = None):
 def make_transform_manager(model_cfg: ModelConfig, ds_cfg: DatasetConfig, set_size: int,
                            opt_args: dict, stage_transform_class, eval_mode: bool):
     """
-    Constructs the appropriate transform manager for the this data.
+    Constructs the appropriate transform manager for this data.
     :param model_cfg: The model config.
     :param ds_cfg: The dataset config.
     :param set_size: The size of the data set.
@@ -1292,16 +1292,16 @@ def make_transform_manager(model_cfg: ModelConfig, ds_cfg: DatasetConfig, set_si
 
     if eval_mode:
         if model_cfg.evaluation_transforms is not None:
-            logger.info(f"Making transform manager from model config EVALUATION transforms.")
-            model_transforms = TransformManager(model_cfg.evaluation_transforms, opt_args)
+            logger.info(f"Making labeled transform manager from model config EVALUATION transforms.")
+            model_transforms = LabeledTransformManager(model_cfg.evaluation_transforms, opt_args)
     else:
         if model_cfg.training_transforms is not None:
-            logger.info(f"Making transform manager from model config TRAINING transforms.")
-            model_transforms = TransformManager(model_cfg.training_transforms, opt_args)
+            logger.info(f"Making labeled transform manager from model config TRAINING transforms.")
+            model_transforms = LabeledTransformManager(model_cfg.training_transforms, opt_args)
 
     if ds_cfg.data_transforms is not None:
-        logger.info(f"Making transform manager from DATASET transforms.")
-        ds_transforms = TransformManager(ds_cfg.data_transforms.transforms, opt_args)
+        logger.info(f"Making labeled transform manager from DATASET transforms.")
+        ds_transforms = LabeledTransformManager(ds_cfg.data_transforms.transforms, opt_args)
         if ds_cfg.data_transforms.seed is not None:
             data_seed = ds_cfg.data_transforms.seed
         else:

--- a/juneberry/loader.py
+++ b/juneberry/loader.py
@@ -79,6 +79,19 @@ def extract_kwargs(instance_dict):
     return {'fq_name': fq_name, 'kwargs': instance_dict.get('kwargs', {})}
 
 
+def extract_kwarg_names(func):
+    """
+    Extracts the names of arguments (past the first) that are of type POSITIONAL_OR_KEYWORD
+    or KEYWORD_ONLY so we omit positional only, or VAR_KEYWORD args.
+    :return:
+    """
+    params = []
+    for i, (k,v) in enumerate(inspect.signature(func).parameters.items()):
+        if i != 0 and ( v.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD or v.kind == inspect.Parameter.KEYWORD_ONLY):
+            params.append(k)
+
+    return params
+
 def construct_instance(fq_name, kwargs: dict, optional_kwargs: dict = None):
     """
     Constructs an instance of the class from the fully qualified name expanding

--- a/juneberry/loader.py
+++ b/juneberry/loader.py
@@ -86,11 +86,12 @@ def extract_kwarg_names(func):
     :return:
     """
     params = []
-    for i, (k,v) in enumerate(inspect.signature(func).parameters.items()):
-        if i != 0 and ( v.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD or v.kind == inspect.Parameter.KEYWORD_ONLY):
+    for i, (k, v) in enumerate(inspect.signature(func).parameters.items()):
+        if i != 0 and (v.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD or v.kind == inspect.Parameter.KEYWORD_ONLY):
             params.append(k)
 
     return params
+
 
 def construct_instance(fq_name, kwargs: dict, optional_kwargs: dict = None):
     """

--- a/juneberry/pytorch/image_dataset.py
+++ b/juneberry/pytorch/image_dataset.py
@@ -58,12 +58,6 @@ class ImageDataset(EpochDataset):
         self.image_cache = {}
         self.no_paging = no_paging
 
-        # If the transforms takes the extended set, use them all
-        self.extended_signature = False
-        if transforms is not None:
-            params = inspect.signature(transforms).parameters.keys()
-            self.extended_signature = set(params) == {'item', 'index', 'epoch'}
-
         # Filters out a warning associated with a known Pillow issue that occurs
         # when opening images.
         warnings.filterwarnings("ignore", "Corrupt EXIF data", UserWarning)
@@ -106,10 +100,6 @@ class ImageDataset(EpochDataset):
         if self.transforms is not None:
             args = {'label': label, 'index': index, 'epoch': self.epoch}
             image, label = self.transforms(image, **args)
-            # if self.extended_signature:
-            #     image = self.transforms(item=image, index=index, epoch=self.epoch)
-            # else:
-            #     image = self.transforms(image)
 
         # We want to pass back a tensor, so convert if it wasn't already converted
         if not isinstance(image, Tensor):

--- a/juneberry/pytorch/image_dataset.py
+++ b/juneberry/pytorch/image_dataset.py
@@ -104,10 +104,12 @@ class ImageDataset(EpochDataset):
             image = Image.open(file_path)
 
         if self.transforms is not None:
-            if self.extended_signature:
-                image = self.transforms(item=image, index=index, epoch=self.epoch)
-            else:
-                image = self.transforms(image)
+            args = {'label': label, 'index': index, 'epoch': self.epoch}
+            image, label = self.transforms(image, **args)
+            # if self.extended_signature:
+            #     image = self.transforms(item=image, index=index, epoch=self.epoch)
+            # else:
+            #     image = self.transforms(image)
 
         # We want to pass back a tensor, so convert if it wasn't already converted
         if not isinstance(image, Tensor):

--- a/juneberry/pytorch/tabular_dataset.py
+++ b/juneberry/pytorch/tabular_dataset.py
@@ -44,12 +44,6 @@ class TabularDataset(EpochDataset):
         """
         super().__init__()
 
-        # If the transforms takes the extended set, use them all
-        self.extended_signature = False
-        if transforms is not None:
-            params = inspect.signature(transforms).parameters.keys()
-            self.extended_signature = set(params) == {'item', 'index', 'epoch'}
-
         self.transforms = transforms
         for item in rows_labels:
             assert len(item) == 2
@@ -74,10 +68,8 @@ class TabularDataset(EpochDataset):
 
         if self.transforms is not None:
             row = row.copy()
-            if self.extended_signature:
-                image = self.transforms(item=row, index=index, epoch=self.epoch)
-            else:
-                row = self.transforms(row)
+            args = {'label': label, 'index': index, 'epoch': self.epoch}
+            row, label = self.transforms(row, **args)
 
         # They want a row as float
         row = np.array(row).astype(np.float32)

--- a/juneberry/transform_manager.py
+++ b/juneberry/transform_manager.py
@@ -22,10 +22,9 @@
 #
 # ======================================================================================================================
 
-import inspect
 import logging
 import sys
-from typing import Any, Dict, Optional
+from typing import Any
 
 import juneberry.loader as loader
 import juneberry.utils as jb_utils

--- a/juneberry/transform_manager.py
+++ b/juneberry/transform_manager.py
@@ -22,8 +22,10 @@
 #
 # ======================================================================================================================
 
+import inspect
 import logging
 import sys
+from typing import Any, Dict, Optional
 
 import juneberry.loader as loader
 import juneberry.utils as jb_utils
@@ -54,53 +56,95 @@ class TransformManager:
             "kwargs": { <kwargs to be passed (expanded) to __init__ on construction> }
         }
     ]
+
+    We assume a call's signature where the first element is always the thing
+    to be transformed, and all other arguments are by name.  So
+    __call__(x, *, opt_1=None, opt2_=None, etc)
     ```
     """
 
     class Entry:
-        def __init__(self, fqcn: str, kwargs: dict = None):
+        def __init__(self, fqcn: str, kwargs: dict = None, opt_args: dict = None):
+            """
+            Initializes an entry which construct an instance with the kwargs and
+            optional args for the function.
+            :param fqcn: Fully Qualified Class Name
+            :param kwargs: The keyword args from the config
+            :param opt_args: Optional construction args
+            """
             self.fqcn = fqcn
             self.kwargs = kwargs
+
+            # The transform - Do NOT call this directly. Use the __call__ API.
             self.transform = None
+            self.extra_params = []
+
+            # Load the instance
+            logger.info(f"Constructing transform: {fqcn} with args: {kwargs}")
+            self.transform = loader.construct_instance(fqcn, kwargs, opt_args)
+
+            # Grab all the extra arguments so we can call it with those
+            self.extra_params = loader.extract_kwarg_names(self.transform)
+            logger.info(f"... wants extra params {self.extra_params}")
+
+        def __call__(self, obj: Any, **kwargs) -> Any:
+            if obj is None:
+                return None
+
+            # Prune down the big pile of kwargs to what they want
+            pruned_args = {}
+            for k in self.extra_params:
+                if k in kwargs:
+                    pruned_args[k] = kwargs[k]
+                else:
+                    logger.error(f"Failed to find arg '{k}' in kwargs. {kwargs} {self.extra_params}")
+                    raise RuntimeError("See log for details.")
+            # pruned_args = {k: kwargs[k] for k in self.extra_params}
+            return self.transform(obj, **pruned_args)
 
     def __init__(self, config: list, opt_args: dict = None):
         """
-        Initializer that takes the augmentations stanza as configuration
+        Initializer that takes the transform stanza as configuration
         :param config: A configuration list of dicts of name, args.
+        :param opt_args: A series of optional arguments to pass in during CONSTRUCTION.
         """
         self.config = []
 
+        # A set of all the optional arguments wanted by all the transforms for preflight verification
+        self.all_opt_args = set()
+
+        # TODO: Switch to prodict
         for i in config:
             if 'fqcn' not in i:
                 logger.error(f"Transform entry does not have required key 'fqcn' {i}")
                 sys.exit(-1)
 
-            entry = TransformManager.Entry(i['fqcn'], i.get('kwargs', None))
+            entry = TransformManager.Entry(i['fqcn'], i.get('kwargs', None), opt_args)
 
-            logger.info(f"Constructing transform: {entry.fqcn} with args: {entry.kwargs}")
-            entry.transform = loader.construct_instance(entry.fqcn, entry.kwargs, opt_args)
+            # Keep a master list (set) of all the extra params wanted
+            self.all_opt_args.update(entry.extra_params)
 
             self.config.append(entry)
 
-    def __call__(self, obj):
+    def __call__(self, obj: Any, **kwargs) -> Any:
         """
         Performs all the transformations, in sequence, on the input and returns the last output.
+
         :param obj: The object to transform.
         :return: The transformed object.
         """
         for entry in self.config:
-            if obj is not None:
-                obj = entry.transform(obj)
+            obj = entry(obj, **kwargs)
 
         return obj
 
-    def transform(self, obj):
+    def transform(self, obj: Any, **kwargs) -> Any:
         """
         Deprecated API for transforming the object.  Use __call__(obj) instead.
         :param obj: The object to transform.
         :return: The transformed object.
         """
-        return self(obj)
+        return self(obj, **kwargs)
 
     def __len__(self) -> int:
         """
@@ -128,11 +172,62 @@ class TransformManager:
         return self.__str__()
 
 
+class LabeledTransformManager(TransformManager):
+    """
+    This transform manager understand that labels CAN BE returned along with the object.
+    Labels are passed in as an optional argument so they are placed into the proper spot,
+    which is usually the second argument. However, we assume correctly called label
+    not by position.
+    """
+
+    def __init__(self, config: list, opt_args: dict = None):
+        """
+        Initializer that takes the transform stanza as configuration
+        :param config: A configuration list of dicts of name, args.
+        :param opt_args: A series of optional arguments to pass in during CONSTRUCTION.
+        """
+        super().__init__(config, opt_args)
+
+    def __call__(self, obj, **kwargs):
+        """
+        Performs all the transformations, in sequence, on the input and returns the last output
+        along with the label.
+        In this version the label is required in the opt_args.
+        :param obj: The object to transform.
+        :return: The transformed object and final label
+        """
+        if 'label' not in kwargs:
+            logger.error("The LabeledTransformManager requires that 'label' be passed in as a kwarg.")
+            raise RuntimeError("See log for details.")
+
+        for entry in self.config:
+            retval = entry(obj, **kwargs)
+
+            # Unpack the return value. If a tuple we assume it is (object, label).  We do NOT
+            # do a list, because that could be real data.
+            if isinstance(retval, tuple):
+                if len(retval) != 2:
+                    logger.error(f"When running transform {entry.fqcn} received a tuple with length {len(retval)} "
+                                 f"when expected two values.")
+                    raise RuntimeError("See log for details.")
+
+                # Split the values and update the label
+                obj, label = retval
+                # print(f"GOT TWO RETURN VALUES {obj} {label}")
+                kwargs["label"] = label
+            else:
+                obj = retval
+
+        # We give back the object and accumulate label
+        return obj, kwargs['label']
+
+
 class StagedTransformManager:
     """
     A callable transform manager that manages the random seed state in a predictable fashion based
     on an initial seed state and the seed index.
     """
+
     def __init__(self, consistent_seed: int, consistent, per_epoch_seed: int, per_epoch):
         """
         Initialize the two stage manager with seeds and transforms for two stages.  The first
@@ -150,7 +245,14 @@ class StagedTransformManager:
         self.per_epoch_transform = per_epoch
         self.per_epoch_seed = per_epoch_seed
 
-    def __call__(self, item, index, epoch):
+    def __call__(self, item, **kwargs):
+        if 'index' not in kwargs or 'epoch' not in kwargs:
+            logger.error("The StagedTransformManager required 'index' and 'epoch' to be passed in as kwargs")
+            raise RuntimeError("See log for details.")
+
+        index = kwargs['index']
+        epoch = kwargs['epoch']
+
         # Capture the random state
         self.save_random_state()
 
@@ -167,6 +269,7 @@ class StagedTransformManager:
         # Restore the state
         self.restore_random_state()
 
+        # TODO: This is probably labeled!!!
         return item
 
     # Extension points
@@ -178,4 +281,3 @@ class StagedTransformManager:
 
     def set_seeds(self, seed):
         pass
-

--- a/scripts/run_system_test.py
+++ b/scripts/run_system_test.py
@@ -60,7 +60,7 @@ CLSFY_TEST_SET = [
         "imagenette_160x160_rgb_unit_test_pyt_resnet18",
         "data_sets/imagenette_unit_test.json",
         1.0,
-        0.49
+        0.47
     ],
     [
         "imagenette_224x224_rgb_unit_test_tf_resnet50",
@@ -91,7 +91,7 @@ OD_GPU_TEST_SET = [
         "data_sets/text_detect_val.json",
         0.92,
         #  Single GPU (9.3), 2 GPU (2.5), 4 GPU (2.0) in testing.
-        0.016
+        0.0159
     ]
 ]
 

--- a/test/moddir/simple_mod.py
+++ b/test/moddir/simple_mod.py
@@ -1,48 +1,26 @@
 #! /usr/bin/
 
-# ==========================================================================================================================================================
-#  Copyright 2021 Carnegie Mellon University.
+# ======================================================================================================================
+# Juneberry - General Release
 #
-#  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
-#  BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
-#  INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
-#  FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
-#  FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+# Copyright 2021 Carnegie Mellon University.
 #
-#  Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
 #
-#  [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.
-#  Please see Copyright notice for non-US Government use and distribution.
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
 #
-#  This Software includes and/or makes use of the following Third-Party Software subject to its own license:
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
 #
-#  1. PyTorch (https://github.com/pytorch/pytorch/blob/master/LICENSE) Copyright 2016 facebook, inc..
-#  2. NumPY (https://github.com/numpy/numpy/blob/master/LICENSE.txt) Copyright 2020 Numpy developers.
-#  3. Matplotlib (https://matplotlib.org/3.1.1/users/license.html) Copyright 2013 Matplotlib Development Team.
-#  4. pillow (https://github.com/python-pillow/Pillow/blob/master/LICENSE) Copyright 2020 Alex Clark and contributors.
-#  5. SKlearn (https://github.com/scikit-learn/sklearn-docbuilder/blob/master/LICENSE) Copyright 2013 scikit-learn 
-#      developers.
-#  6. torchsummary (https://github.com/TylerYep/torch-summary/blob/master/LICENSE) Copyright 2020 Tyler Yep.
-#  7. pytest (https://docs.pytest.org/en/stable/license.html) Copyright 2020 Holger Krekel and others.
-#  8. pylint (https://github.com/PyCQA/pylint/blob/main/LICENSE) Copyright 1991 Free Software Foundation, Inc..
-#  9. Python (https://docs.python.org/3/license.html#psf-license) Copyright 2001 python software foundation.
-#  10. doit (https://github.com/pydoit/doit/blob/master/LICENSE) Copyright 2014 Eduardo Naufel Schettino.
-#  11. tensorboard (https://github.com/tensorflow/tensorboard/blob/master/LICENSE) Copyright 2017 The TensorFlow 
-#                  Authors.
-#  12. pandas (https://github.com/pandas-dev/pandas/blob/master/LICENSE) Copyright 2011 AQR Capital Management, LLC,
-#             Lambda Foundry, Inc. and PyData Development Team.
-#  13. pycocotools (https://github.com/cocodataset/cocoapi/blob/master/license.txt) Copyright 2014 Piotr Dollar and
-#                  Tsung-Yi Lin.
-#  14. brambox (https://gitlab.com/EAVISE/brambox/-/blob/master/LICENSE) Copyright 2017 EAVISE.
-#  15. pyyaml  (https://github.com/yaml/pyyaml/blob/master/LICENSE) Copyright 2017 Ingy döt Net ; Kirill Simonov.
-#  16. natsort (https://github.com/SethMMorton/natsort/blob/master/LICENSE) Copyright 2020 Seth M. Morton.
-#  17. prodict  (https://github.com/ramazanpolat/prodict/blob/master/LICENSE.txt) Copyright 2018 Ramazan Polat
-#               (ramazanpolat@gmail.com).
-#  18. jsonschema (https://github.com/Julian/jsonschema/blob/main/COPYING) Copyright 2013 Julian Berman.
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
 #
-#  DM21-0689
+# DM21-0884
 #
-# ==========================================================================================================================================================
+# ======================================================================================================================
 
 
 def binary_function(a, b):
@@ -68,6 +46,39 @@ class ClassWithInitAndUnaryCall:
 
     def __call__(self, arg):
         return f"{self.name} {arg}"
+
+    def get_name(self):
+        return self.name
+
+
+class ClassWithUnaryCallWithOptArg1:
+    def __init__(self):
+        self.name = "No name"
+
+    def __call__(self, arg, opt1=None):
+        return f"{arg} {opt1}"
+
+    def get_name(self):
+        return self.name
+
+
+class ClassWithUnaryCallWithOptArg2:
+    def __init__(self):
+        self.name = "No name"
+
+    def __call__(self, arg, opt2=None):
+        return f"{arg} {opt2}"
+
+    def get_name(self):
+        return self.name
+
+
+class LabeledTransformExample:
+    def __init__(self):
+        self.name = "No name"
+
+    def __call__(self, arg, *, label, opt1=None):
+        return f"{arg} {opt1}", int(label) + 1
 
     def get_name(self):
         return self.name

--- a/test/test_transform_manager.py
+++ b/test/test_transform_manager.py
@@ -25,7 +25,11 @@
 import juneberry.transform_manager
 
 
-def test_transform():
+def test_init_with_args():
+    """
+    Tests that we can construct a transform with specific kwargs
+    :return:
+    """
     config = [
         {
             'fqcn': 'moddir.simple_mod.ClassWithInitAndUnaryCall',
@@ -39,15 +43,126 @@ def test_transform():
     assert ttm.transform("baggins") == 'frodo baggins'
 
 
-def test_opt_args():
+def test_inti_with_opt_args() -> None:
+    """
+    Tests that we can construct something with optional args.
+    :return: None
+    """
     config = [
         {
             'fqcn': 'moddir.simple_mod.ClassWithInitAndUnaryCall'
         }
     ]
 
+    # NOTE: 'name' is expected but bar isn't, but 'bar' should be filtered out.
     opt_args = {"name": "frodo", "bar": 1234}
     ttm = juneberry.transform_manager.TransformManager(config, opt_args)
     assert len(ttm) == 1
     assert ttm.get_fqn(0) == 'moddir.simple_mod.ClassWithInitAndUnaryCall'
     assert ttm.transform("baggins") == 'frodo baggins'
+
+
+def test_call_with_opt_args():
+    """
+    In this test we see if the TTM can take a set of optional arguments and apply
+    the correct ones to the appropriate transforms.
+    :return: None
+    """
+    config = [
+        {
+            'fqcn': 'moddir.simple_mod.ClassWithUnaryCallWithOptArg1'
+        },
+        {
+            'fqcn': 'moddir.simple_mod.ClassWithUnaryCallWithOptArg2'
+        }
+    ]
+
+    ttm = juneberry.transform_manager.TransformManager(config)
+    opt_args = {'opt1': 'gamgee', 'opt2': 'hobbit', 'other': 'unused'}
+    assert len(ttm) == 2
+    assert ttm.get_fqn(0) == 'moddir.simple_mod.ClassWithUnaryCallWithOptArg1'
+    assert ttm.get_fqn(1) == 'moddir.simple_mod.ClassWithUnaryCallWithOptArg2'
+    assert ttm.all_opt_args == {'opt1', 'opt2'}
+
+    # Each transform appends the optX arg to the object. Since we run them all in order,
+    # we should get the '<obj> <opt1> <opt2>' as output.
+    assert ttm.transform("sam", **opt_args) == 'sam gamgee hobbit'
+
+
+def test_labeled_transforms():
+    """
+    In this test we look to see that the LabeledTransformManager supports transforms
+    that CAN return two values (obj, label) and that we update the label.
+    :return:
+    """
+    config = [
+        {
+            'fqcn': 'moddir.simple_mod.LabeledTransformExample'
+        },
+        {
+            'fqcn': 'moddir.simple_mod.ClassWithUnaryCallWithOptArg2'
+        }
+    ]
+
+    ttm = juneberry.transform_manager.LabeledTransformManager(config)
+    opt_args = {'opt1': 'took', 'opt2': 'hobbit', 'label': 3, 'other': 'unused'}
+    assert len(ttm) == 2
+    assert ttm.get_fqn(0) == 'moddir.simple_mod.LabeledTransformExample'
+    assert ttm.get_fqn(1) == 'moddir.simple_mod.ClassWithUnaryCallWithOptArg2'
+    assert ttm.all_opt_args == {'opt1', 'opt2', 'label'}
+
+    # In this case our labeled transform appends the opt arg and increments the number.
+    # We can also mix in non-label changing ones that also appends data.
+    assert ttm.transform("peregrine", **opt_args) == ('peregrine took hobbit', 4)
+
+
+class StagedTransformManagerHarness(juneberry.transform_manager.StagedTransformManager):
+    def __init__(self, consistent_seed: int, consistent, per_epoch_seed: int, per_epoch):
+        super().__init__(consistent_seed, consistent, per_epoch_seed, per_epoch)
+        self.save_called = False
+        self.restore_called = False
+        self.set_seeds_called = []
+
+    def save_random_state(self):
+        self.save_called = True
+
+    def restore_random_state(self):
+        self.restore_called = True
+
+    def set_seeds(self, seed):
+        self.set_seeds_called.append(seed)
+
+    def reset(self):
+        self.save_called = False
+        self.restore_called = False
+        self.set_seeds_called = []
+
+
+class ConcatTransform():
+    def __init__(self, val):
+        self.val = val
+
+    def __call__(self, obj):
+        return f"{obj} {self.val}"
+
+
+def test_staged_transform():
+    """
+    A base case test for a staged transform manager.
+    :return:
+    """
+    consistent = ConcatTransform('baggins')
+    per_epoch = ConcatTransform('hobbit')
+    stm = StagedTransformManagerHarness(
+        consistent_seed=100,
+        consistent=consistent,
+        per_epoch_seed=5,
+        per_epoch=per_epoch)
+
+    res = stm("frodo", index = 1, epoch= 2)
+    assert stm.save_called
+    assert stm.restore_called
+    # The seeds should be consistent + index, per_epoch + index + epoch
+    assert stm.set_seeds_called == [100 + 1, 5 + 1 + 2]
+    assert res == "frodo baggins hobbit"
+

--- a/test/tf_test/test_data.py
+++ b/test/tf_test/test_data.py
@@ -102,7 +102,7 @@ def test_dataset(tmp_path):
 
     from juneberry.config.model import ShapeHWC
     hwc = ShapeHWC(32, 32, 3)
-    image_ds = tf_data.TFImageDataSequence(data_list, 2, lambda x: x.resize((32, 32)), hwc)
+    image_ds = tf_data.TFImageDataSequence(data_list, 2, (lambda x, **args: (x.resize((32, 32)), args["label"])), hwc)
 
     for tmp_data, tmp_labels in image_ds:
         # print(f"data:{type(tmp_data)} shape:{tmp_data.shape} "


### PR DESCRIPTION
Transforms can now accept labels as optional arguments and can optionally return (item, label) pairs.

In doing this I cleaned up the way in which optional arguments were passed in for the Staged transform. Previously we specially detected the signature (order was important) but now we just detect all optional arguments (except 'kwargs') past the first. This exposes those fields for general purpose and paves the way for future expansion.

The ugly part was how the return values are processed. We now have a "LabeledTransformManager" subclass that deal with label handling.