### PR TITLE
bugfix/JB-426-eval-bbox-fix

### DIFF
--- a/juneberry/config/coco_utils.py
+++ b/juneberry/config/coco_utils.py
@@ -425,7 +425,11 @@ def generate_bbox_images(coco_json: Path, lab, dest_dir: str = None, sample_limi
 
         # Draw the boxes on the image
         with Image.open(img_file) as file:
-            img = file.convert('RGB')
+            # Conditional to check what type of data we are working with
+            if not (file.mode == "I;16" or file.mode == "I"):
+                img = file.convert('RGB')
+            else:
+                img = file.convert('I')
         draw = ImageDraw.Draw(img)
 
         # colorblind palette: https://davidmathlogic.com/colorblind  IBM version


### PR DESCRIPTION
### 05/17/2022
**Juneberry**
`juneberry/config/coco_utils.py`
A slight adjustment was made to `coco_utils.py` to remove the assumption that we will always be working with 3-channel RGB when performing evaluations. This change adds in a conditional to first check what `Image.mode` we are working with and then proceeds with the conversions accordingly.

