### PR TITLE
Added ability to target specific array elements as experiment outline…

### DIFF
--- a/bin/jb_generate_experiments
+++ b/bin/jb_generate_experiments
@@ -353,11 +353,16 @@ def get_combo_name(chosen: dict, possible_options: list) -> str:
 
     # For each key in the combination to be implemented
     for key in chosen:
+        # The modded key is necessary to account for cases where the target variable is a
+        # particular element in an array.
+        modded_key = None
+        if "[" in key:
+            modded_key = str(key).split("[")[0]
 
         # Locate the variable in the list
         option: jb_exp_outline.Variable
         for option in possible_options:
-            if option.config_field == key:
+            if option.config_field == key or option.config_field == modded_key:
 
                 # Add the nickname in the combo_name if there is one
                 if option.nickname:
@@ -391,8 +396,18 @@ def apply_nested_parameter(config: dict, parameter: str, value) -> dict:
 
     # Traverse the dictionary, stopping at the final component.
     for component in components[:-1]:
+
+        # If there's a bracket in the component name, that indicates a particular element of
+        # an array is being targeted. The steps to set the cur_key are a little different in
+        # this case to account for the targeted element in the array.
+        if "[" in component:
+            idx = int(component.split("[")[1].split("]")[0])
+            component = component.split("[")[0]
+            cur_key = cur_key[component][idx]
+            continue
+
         if not isinstance(cur_key, dict) or component not in cur_key:
-            logger.error(f"Failed to find '{parameter}' in config. Check parameter validity. EXITING")
+            logger.error(f"Failed to find '{parameter}' in config. Check parameter validity. Exiting.")
             sys.exit(-1)
         cur_key = cur_key[component]
 
@@ -428,7 +443,8 @@ def apply_parameter(config: dict, parameter: str, value) -> dict:
             config = apply_parameter(config, component, value[component])
 
     # "Dot notation" is how we handle nested parameters. We'll call a separate function to handle that.
-    elif "." in parameter:
+    # "Bracket notation" can also be handled by this same nested process.
+    elif "." or "[" in parameter:
         config = apply_nested_parameter(config, parameter, value)
 
     # If the parameter isn't grouped or nested, it's "normal" so we can set it just like it's a
@@ -490,7 +506,7 @@ def validate_variables(variables: list) -> None:
 
     if error_count > 0:
         error_str = "error" if error_count == 1 else "errors"
-        logger.error(f"Found {error_count} {error_str} when validating variables. EXITING.")
+        logger.error(f"Found {error_count} {error_str} when validating variables. Exiting.")
         sys.exit(-1)
 
 

--- a/docs/specs/experiment_outline_specification.md
+++ b/docs/specs/experiment_outline_specification.md
@@ -160,6 +160,11 @@ notation ensures that if lrSchedule A is chosen for the model config, then it wi
 Args group 1 (and never Args group 2). Additionally, if lrSchedule B gets chosen, then Args group 2 must 
 be used (and never Args group 1).
 
+When the value for a particular parameter is an array, you can use brackets "[]" to target a specific 
+element in that array to be a variable. For example, a config field of `training_transforms[1].kwargs.size` 
+would look inside the model config for a parameter named "training_transforms", take the first element inside 
+that array, and vary the "kwargs.size" property of that element.
+
 ### vals
 This key should be a list of the vals you would like to assign to the variable. The correct type for 
 the elements in this list will depend on the parameter specified in the config_field. Integers, strings, 


### PR DESCRIPTION
… variables

The extra experiment outline fields that I had proposed ended up being more trouble than they were worth. It was much easier to just get a string like `training_transforms[1].kwargs.size` to work.