### PR TITLE
JB-442 nested datasets (support slashes)

### DIFF
--- a/juneberry/data.py
+++ b/juneberry/data.py
@@ -212,7 +212,7 @@ def make_eval_manifest_file(lab: Lab, dataset_config: DatasetConfig,
         logger.info("Evaluating using ONLY the validation portion of the split data.")
         eval_list = split
 
-    output_path = str(model_manager.get_eval_manifest_path(dataset_config.file_path).resolve())
+    output_path = str(model_manager.get_eval_dir_mgr(str(dataset_config.file_path)).get_manifest_path())
 
     label_names = get_label_mapping(model_manager=model_manager, model_config=model_config, train_config=dataset_config)
     coco_style = coco_utils.convert_jbmeta_to_coco(eval_list, label_names)

--- a/juneberry/detectron2/data.py
+++ b/juneberry/detectron2/data.py
@@ -72,7 +72,8 @@ def register_eval_manifest_file(lab: Lab, model_manager: ModelManager, dataset_c
     :param dataset_config: The dataset configuration
     :return: None
     """
-    manifest_path = model_manager.get_eval_manifest_path(dataset_config.file_path).resolve()
+    path_str = model_manager.get_eval_dir_mgr(str(dataset_config.file_path)).get_manifest_path()
+    manifest_path = str(Path(path_str).resolve())
 
     if not Path(manifest_path).exists():
         logger.error(f"Could not find the evaluation manifest. {manifest_path}"

--- a/juneberry/detectron2/evaluator.py
+++ b/juneberry/detectron2/evaluator.py
@@ -81,7 +81,7 @@ class Evaluator(EvaluatorBase):
         self.obtain_model()
 
         # Test for the presence of the annotations file.
-        anno_file = Path(self.output_dir) / self.model_manager.get_eval_manifest_path(self.dataset_config.file_path)
+        anno_file = Path(self.output_dir) / self.eval_dir_mgr.get_manifest_path()
         logger.info(f"Checking for annotations file at {anno_file}")
         if anno_file.exists():
             logger.info(f"Annotations file exists. It would be deleted and regenerated during the evaluation.")
@@ -212,7 +212,7 @@ class Evaluator(EvaluatorBase):
         out = self.eval_dir_mgr.get_detections_anno_path()
 
         # Find category list
-        eval_manifest_path = self.model_manager.get_eval_manifest_path(self.eval_dataset_config.file_path)
+        eval_manifest_path = self.eval_dir_mgr.get_manifest_path()
         category_list = jb_data.get_category_list(eval_manifest_path=eval_manifest_path,
                                                   model_manager=self.model_manager,
                                                   train_config=self.dataset_config,

--- a/juneberry/lab.py
+++ b/juneberry/lab.py
@@ -156,7 +156,7 @@ class Lab:
         :return: The config object.
         """
         full_path = Path(self.workspace(ws_key)) / config_path
-        return DatasetConfig.load(str(full_path), relative_path=full_path.parent)
+        return DatasetConfig.load(config_path, relative_path=full_path.parent)
 
     def load_lab_profile(self, model_name: str = None, ws_key='default') -> LabProfile:
         """

--- a/juneberry/mmdetection/evaluator.py
+++ b/juneberry/mmdetection/evaluator.py
@@ -135,7 +135,7 @@ class Evaluator(EvaluatorBase):
         cfg.data_root = str(self.lab.data_root())
 
         cfg.data.test.data_root = str(self.lab.data_root().resolve())
-        cfg.data.test.ann_file = str(self.eval_dir_mgr.get_manifest_path())
+        cfg.data.test.ann_file = str(self.eval_dir_mgr.get_manifest_path().resolve())
         cfg.data.test.img_prefix = ""
         cfg.data.test.classes = classes
         cfg.data.test.test_mode = True

--- a/juneberry/mmdetection/evaluator.py
+++ b/juneberry/mmdetection/evaluator.py
@@ -25,13 +25,13 @@
 from collections import OrderedDict
 import itertools
 import logging
-import mmcv
-import numpy as np
+from pathlib import Path
 import sys
 from types import SimpleNamespace
 import warnings
 
 # Multi-gpu needs to do MMDDP
+import mmcv
 from mmcv.parallel import MMDataParallel
 
 # Multi-gpu needs to do init_dist
@@ -43,6 +43,8 @@ from mmdet.datasets import build_dataloader, build_dataset
 from mmdet.datasets.api_wrappers import COCOeval
 from mmdet.datasets.coco import CocoDataset
 from mmdet.models import build_detector
+
+import numpy as np
 
 import juneberry.config.coco_utils as coco_utils
 from juneberry.config.dataset import DatasetConfig
@@ -135,7 +137,7 @@ class Evaluator(EvaluatorBase):
         cfg.data_root = str(self.lab.data_root())
 
         cfg.data.test.data_root = str(self.lab.data_root().resolve())
-        cfg.data.test.ann_file = str(self.eval_dir_mgr.get_manifest_path().resolve())
+        cfg.data.test.ann_file = str(Path(self.eval_dir_mgr.get_manifest_path()).resolve())
         cfg.data.test.img_prefix = ""
         cfg.data.test.classes = classes
         cfg.data.test.test_mode = True

--- a/juneberry/mmdetection/evaluator.py
+++ b/juneberry/mmdetection/evaluator.py
@@ -134,9 +134,8 @@ class Evaluator(EvaluatorBase):
         cfg.dataset_type = 'COCODataset'
         cfg.data_root = str(self.lab.data_root())
 
-        coco_path = self.model_manager.get_eval_manifest_path(ds_cfg.file_path).resolve()
         cfg.data.test.data_root = str(self.lab.data_root().resolve())
-        cfg.data.test.ann_file = str(coco_path.resolve())
+        cfg.data.test.ann_file = str(self.eval_dir_mgr.get_manifest_path())
         cfg.data.test.img_prefix = ""
         cfg.data.test.classes = classes
         cfg.data.test.test_mode = True
@@ -175,7 +174,7 @@ class Evaluator(EvaluatorBase):
 
         # This output should be EXACTLY what we used, so we should be able to feed
         # this into mmdetection's test.py.
-        out_path = self.model_manager.get_platform_eval_config(self.eval_dataset_config_path, 'py')
+        out_path = self.model_manager.get_eval_dir_mgr(str(self.eval_dataset_config_path)).get_platform_config('.py')
         with open(out_path, "w") as out_cfg:
             logger.info(f"Writing out config to: {out_path}")
             out_cfg.write(cfg.pretty_text)
@@ -231,7 +230,7 @@ class Evaluator(EvaluatorBase):
         # [batch] x [num_classes] x [ bbox(l,t,r,b] + score ]
 
         # Grab category mapping
-        eval_manifest_path = self.model_manager.get_eval_manifest_path(self.eval_dataset_config.file_path)
+        eval_manifest_path = self.eval_dir_mgr.get_manifest_path()
         category_list = jb_data.get_category_list(eval_manifest_path=eval_manifest_path,
                                                   model_manager=self.model_manager,
                                                   # train_config = self.dataset_config,

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -38,11 +38,6 @@ def test_eval_dir():
     root = Path('models') / 'TestModel' / '1999'
     eval_dir_root = root / 'eval' / 'TestDataset'
 
-    assert mm.get_eval_root_dir() == root / 'eval'
-    assert mm.get_eval_dir('TestDataset') == eval_dir_root
-    assert mm.get_platform_eval_config('TestDataset') == eval_dir_root / 'platform_config.json'
-    assert mm.get_eval_manifest_path('TestDataset') == eval_dir_root / 'eval_manifest.json'
-
     eval_dir_mgr = mm.get_eval_dir_mgr('TestDataset')
     eval_dir_mgr.setup()
 


### PR DESCRIPTION
The issues is that we used to just pull off the ".stem" for the eval directory name. Now, we use the entire path within the workspace, except when in data_sets.  For non-data_sets files, this could get quite noisy, but we can probably come up with better rules later.

What made this hard was that because we were using ".stem" some places were doing full paths and without the lab, we can't do relative. In the long run, we probably need to pass the lab into the model manager when creating it, but for now the assumption that the cwd is the workspace should be okay.