### PR TITLE
Jb 459 experiment with pretrained models

### DIFF
--- a/bin/jb_experiment_to_rules
+++ b/bin/jb_experiment_to_rules
@@ -121,7 +121,10 @@ class RuleMaker:
             # Predictions
             if model.tests:
                 for test in model.tests:
-                    inputs = [model_mgr.get_model_path(), test.dataset_path]
+                    if model.train:
+                        inputs = [model_mgr.get_model_path(), test.dataset_path]
+                    else:
+                        inputs = [test.dataset_path]
                     outputs = model_mgr.get_evaluation_output_list(test.dataset_path)
                     command = [JB_EVALUATE_COMMAND, model_mgr.model_name, test.dataset_path]
                     if test.classify:

--- a/bin/jb_experiment_to_rules
+++ b/bin/jb_experiment_to_rules
@@ -124,6 +124,9 @@ class RuleMaker:
                     if model.train:
                         inputs = [model_mgr.get_model_path(), test.dataset_path]
                     else:
+                        # If the model isn't being trained, then a model file doesn't have to exist.
+                        # The model architecture can create a fully functional pretrained model from the
+                        # underlying platform such as torchvision pretrained models.
                         inputs = [test.dataset_path]
                     outputs = model_mgr.get_evaluation_output_list(test.dataset_path)
                     command = [JB_EVALUATE_COMMAND, model_mgr.model_name, test.dataset_path]

--- a/bin/jb_experiment_to_rules
+++ b/bin/jb_experiment_to_rules
@@ -65,6 +65,10 @@ class RuleMaker:
 
     def add_training(self):
         for model in self.experiment_config.models:
+            # If they don't want this trained, then we are done.
+            if not model.train:
+                continue
+
             model_mgr = ModelManager(model.name)
             model_config = ModelConfig.load(model_mgr.get_model_config())
 
@@ -128,7 +132,10 @@ class RuleMaker:
                         command.append('--useValSplit')
                     doc = " ".join([str(x) for x in command])
                     clean_extras = model_mgr.get_predictions_clean_extras_list()
-                    requirements = [model['train_rule_id']]
+                    if 'train_rule_id' in model:
+                        requirements = [model['train_rule_id']]
+                    else:
+                        requirements = []
 
                     cmd_id = workflow.add_rule(inputs, outputs, command, doc, clean_extras, requirements)
 

--- a/bin/jb_generate_watermark_eval
+++ b/bin/jb_generate_watermark_eval
@@ -230,9 +230,6 @@ def main():
     # For now, we do ten sizes from 10% to 100%. We should probably allow switches/configs for this.
     scales = [round(0.1 * x, 1) for x in range(1, 11)]
 
-    for scale in scales:
-        print(type(scale))
-
     # Generate the dataset configs and experiment config
     generate_experiment(args.experimentName,
                         args.modelName,

--- a/bin/jb_generate_watermark_eval
+++ b/bin/jb_generate_watermark_eval
@@ -180,7 +180,7 @@ def generate_experiment(experiment_name: str, model_name: str, scales: list, tar
     exp_config.format_version = "0.2.0"
 
     # Add the model stanza with all the tests
-    exp_config.models = [Model(name=model_name, tests=test_list)]
+    exp_config.models = [Model(name=model_name, tests=test_list, train=False)]
 
     # Add the reports stanza
     report = Report(description="",

--- a/docs/specs/experiment_configuration_specification.md
+++ b/docs/specs/experiment_configuration_specification.md
@@ -39,6 +39,7 @@ and the generation of some number of reports from aggregates of the test results
                     "use_val_split": false
                 }
             ],
+            "train": <OPTONAL> - True to train the model, False to just use existing model.pt.  Default is True.
             "version": <OPTIONAL - which version of the model to use>,
         }
     ],
@@ -122,6 +123,11 @@ This is an integer value that will control how many of the top-K predicted class
 for each input in the predictions file. This value is used as the "--classify" argument when 
 jb_make_predictions is run. Since this field is not optional, set this property to zero if you do not 
 want the predictions script to perform classifications. 
+
+### train
+By default all models are trained before evaluation and reports are run. If this flag is setp to false,
+then we assume the model was training in some other fashion, and correspondingly we won't generate rules
+to train (or clean) the model.
 
 ### version
 **Optional** string that indicates which version of the model to use.

--- a/docs/specs/experiment_configuration_specification.md
+++ b/docs/specs/experiment_configuration_specification.md
@@ -39,7 +39,7 @@ and the generation of some number of reports from aggregates of the test results
                     "use_val_split": false
                 }
             ],
-            "train": <OPTONAL> - True to train the model, False to just use existing model.pt.  Default is True.
+            "train": <OPTONAL> - True to train the model, False to just use existing model file. Default is True.
             "version": <OPTIONAL - which version of the model to use>,
         }
     ],
@@ -125,8 +125,8 @@ jb_make_predictions is run. Since this field is not optional, set this property 
 want the predictions script to perform classifications. 
 
 ### train
-By default all models are trained before evaluation and reports are run. If this flag is setp to false,
-then we assume the model was training in some other fashion, and correspondingly we won't generate rules
+By default, all models are trained before evaluation and reports are run. When this flag is set to false,
+the model is assumed to have been trained outside of Juneberry, so no experiment rules will be generated 
 to train (or clean) the model.
 
 ### version

--- a/juneberry/config/experiment.py
+++ b/juneberry/config/experiment.py
@@ -53,10 +53,15 @@ class ModelTest(Prodict):
 
 
 class Model(Prodict):
+    def init(self):
+        self.train = True
+        self.onnx = False
+
     filters: List[str]
     name: str
     onnx: bool
     tests: List[ModelTest]
+    train: bool
     version: str
 
 

--- a/juneberry/config/experiment.py
+++ b/juneberry/config/experiment.py
@@ -53,16 +53,16 @@ class ModelTest(Prodict):
 
 
 class Model(Prodict):
-    def init(self):
-        self.train = True
-        self.onnx = False
-
     filters: List[str]
     name: str
     onnx: bool
     tests: List[ModelTest]
     train: bool
     version: str
+
+    def init(self):
+        self.train = True
+        self.onnx = False
 
 
 class ReportTest(Prodict):

--- a/juneberry/evaluation/utils.py
+++ b/juneberry/evaluation/utils.py
@@ -267,7 +267,7 @@ def verify_model_hash(evaluator: Evaluator, evaluated_model_hash, onnx=False):
     # If Juneberry was used to train the model, retrieve the hash from the training output file
     # and verify the hash matches the hash of the model used to evaluate the data.
     training_output_file_path = evaluator.model_manager.get_training_out_file()
-    if training_output_file_path.is_file():
+    if training_output_file_path.exists():
         training_output = TrainingOutput.load(training_output_file_path)
 
         # Determine which hash to retrieve based on the ONNX boolean.

--- a/juneberry/filesystem.py
+++ b/juneberry/filesystem.py
@@ -269,7 +269,7 @@ class ExperimentManager:
 
     def get_experiment_base_dataset(self):
         """ :return: The path to the experiment's base dataset config. """
-        return self.get_experiment_datasets_dir() / "base_data_set.json"
+        return self.experiment_dir_path / "base_data_set.json"
 
     def get_experiment_dataset_path(self, dataset_name: str):
         """ :return: The path to a dataset file inside the experiment's data_sets directory. """

--- a/juneberry/pytorch/evaluation/default.py
+++ b/juneberry/pytorch/evaluation/default.py
@@ -71,7 +71,7 @@ class PyTorchEvaluationOutput:
         if evaluator.model_manager.get_pytorch_model_path().exists():
             evaluated_model_hash = jbfs.generate_file_hash(evaluator.model_manager.get_pytorch_model_path())
 
-            # If the model Juneberry trained the model, a hash would have been calculated after training.
+            # If the Juneberry trained the model, a hash would have been calculated after training.
             # Compare that hash (if it exists) to the hash of the model being evaluated.
             jb_eval_utils.verify_model_hash(evaluator, evaluated_model_hash)
 

--- a/juneberry/pytorch/evaluation/default.py
+++ b/juneberry/pytorch/evaluation/default.py
@@ -67,12 +67,13 @@ class PyTorchEvaluationOutput:
         # Perform the common eval output processing steps for a classifier.
         jb_eval_utils.prepare_classification_eval_output(evaluator)
 
-        # Calculate the hash of the model that was used to conduct the evaluation.
-        evaluated_model_hash = jbfs.generate_file_hash(evaluator.model_manager.get_pytorch_model_path())
+        # Calculate the hash of the model that was used to conduct the evaluation if we have a serialized one
+        if evaluator.model_manager.get_pytorch_model_path().exists():
+            evaluated_model_hash = jbfs.generate_file_hash(evaluator.model_manager.get_pytorch_model_path())
 
-        # If the model Juneberry trained the model, a hash would have been calculated after training.
-        # Compare that hash (if it exists) to the hash of the model being evaluated.
-        jb_eval_utils.verify_model_hash(evaluator, evaluated_model_hash)
+            # If the model Juneberry trained the model, a hash would have been calculated after training.
+            # Compare that hash (if it exists) to the hash of the model being evaluated.
+            jb_eval_utils.verify_model_hash(evaluator, evaluated_model_hash)
 
         # If requested, get the top K classes predicted for each input.
         if evaluator.top_k:

--- a/juneberry/pytorch/evaluation/evaluator.py
+++ b/juneberry/pytorch/evaluation/evaluator.py
@@ -231,7 +231,8 @@ class Evaluator(EvaluatorBase):
             logger.info(f"Loading model weights...")
             self.model = pyt_utils.load_model(model_path, self.model, self.model_config.pytorch.strict)
         else:
-            logger.warning(f"No 'model.pt' found, running with plain model. Expected to find: {model_path}")
+            logger.warning(f"No 'model.pt' found, running with default model produced from model architecture. "
+                           f"Expected to find: {model_path}")
 
         # If a GPU is present, wrap the model in DataParallel.
         if self.use_cuda:

--- a/juneberry/pytorch/evaluation/evaluator.py
+++ b/juneberry/pytorch/evaluation/evaluator.py
@@ -226,9 +226,12 @@ class Evaluator(EvaluatorBase):
             logger.info(f"Model config does not contain model transforms. Skipping model transform application.")
 
         # Load the weights into the model.
-        logger.info(f"Loading model weights...")
-        self.model = pyt_utils.load_model(self.model_manager.get_pytorch_model_path(), self.model,
-                                          self.model_config.pytorch.strict)
+        model_path = self.model_manager.get_pytorch_model_path()
+        if model_path.exists():
+            logger.info(f"Loading model weights...")
+            self.model = pyt_utils.load_model(model_path, self.model, self.model_config.pytorch.strict)
+        else:
+            logger.warning(f"No 'model.pt' found, running with plain model. Expected to find: {model_path}")
 
         # If a GPU is present, wrap the model in DataParallel.
         if self.use_cuda:

--- a/juneberry/pytorch/utils.py
+++ b/juneberry/pytorch/utils.py
@@ -178,7 +178,7 @@ def save_model(model_manager: ModelManager, model, input_sample, native, onnx) -
         torch.onnx.export(model, input_sample, model_manager.get_onnx_model_path(), export_params=True)
 
 
-def load_model(model_path, model, strict: bool) -> None:
+def load_model(model_path, model, strict: bool):
     """
     Loads the model weights from the model directory using our model naming scheme and format.
     :param model_path: The model directory.

--- a/juneberry/schemas/experiment_schema.json
+++ b/juneberry/schemas/experiment_schema.json
@@ -51,6 +51,7 @@
                             "required": [ "dataset_path", "tag" ]
                         }
                     },
+                    "train": { "type": "boolean" },
                     "version": { "type": "string" }
                 },
                 "required": [ "name", "tests" ]


### PR DESCRIPTION
I added a 'train' flag which defaults to 'true' to the models stanza in the experiment config (not outline). If setting the flag to false, then jb_experiment_to_rules will NOT general a rule for jb_train for the model and therefore no doit action is created. The train flag is set to false by jb_generate_watermark_eval so that the model will not be trained.

To test you can set the flag anywhere in the chain and the re-generate downstream configs. Let me know if you want to insert it somewhere.  Remmeber the chain is: jb_generate_watermark_eval -> experiment config -> rules.json -> main_dodo.py.

Probably the easiest practical thing to get the benefit now is to modify the experiment config and delete the rules.json and main_dodo.py JB should automatically regen those two files.