### PR TITLE
Jb 453 tuning unit tests

### DIFF
--- a/bin/jb_tune
+++ b/bin/jb_tune
@@ -97,7 +97,7 @@ def main():
     tuner.sprout = sprout
 
     # Perform hyperparameter tuning on the model.
-    tuner.tune()
+    tuner.tune(dryrun=sprout.dryrun)
 
     logger.info(f"jb_tune is done.")
 

--- a/docs/specs/report_configuration_specification.md
+++ b/docs/specs/report_configuration_specification.md
@@ -1,6 +1,30 @@
 Report Configuration Specification
-==========
-
+========== 
+<!-- TOC -->
+* [Introduction](report_configuration_specification.md#introduction)
+* Report Config Structures
+  * [Basic Report Config Structure](report_configuration_specification.md#Basic-Report-Config-Structure)
+  * [Report Config Structure Extensions](report_configuration_specification.md#Report-Config-Structure-Extensions)
+    * [Experiment Outline](report_configuration_specification.md#report-config-structure-extensions---experiment-outline)
+    * [Experiments](report_configuration_specification.md#report-config-structure-extensions---experiments)
+  * [Report Specific Config Structures](report_configuration_specification.md#Report-Specific-Config-Structures)
+    * [ROC Report](report_configuration_specification.md#ROC-Report)
+    * [PR Report](report_configuration_specification.md#PR-Report)
+    * [Summary Report](report_configuration_specification.md#Summary-Report)
+  * [Plugin Structure](report_configuration_specification.md#Plugin-Structure)
+  * [Structure Adjustments in an Experiment Config](report_configuration_specification.md#Structure-Adjustments-in-an-Experiment-Config)
+    * [ROC Report](report_configuration_specification.md#Experiment-Config-ROC-Report-Stanza-Differences)
+    * [PR Report](report_configuration_specification.md#Experiment-Config-PR-Report-Stanza-Differences)
+    * [Summary Report](report_configuration_specification.md#Experiment-Config-Summary-Report-Stanza-Differences)
+    * [Custom Report](report_configuration_specification.md#Experiment-Config-Custom-Report-Stanza-Differences)
+* [Details](report_configuration_specification.md#Details)
+  * [Reports](report_configuration_specification.md#reports)
+  * [Experiment Outline Extensions](report_configuration_specification.md#details---experiment-outline-extensions)
+  * [Experiment Extensions](report_configuration_specification.md#details---experiment-extensions)
+  * [ROC Report](report_configuration_specification.md#details---roc-report)
+  * [PR Report](report_configuration_specification.md#details---pr-report)
+  * [Summary Report](report_configuration_specification.md#details---summary-report)
+<!-- TOC -->
 
 # Introduction
 This document describes the JSON format used in a Juneberry Report configuration file. Juneberry 

--- a/test/test_sprouts.py
+++ b/test/test_sprouts.py
@@ -275,7 +275,7 @@ class TestTuningSprout(TestCase):
         assert sprout.log_level == logging.INFO
         assert sprout.profile_name is None
 
-    def test_tuning_sprout_training_namespace(self):
+    def test_tuning_sprout_tuning_namespace(self):
         """
         This test confirms every attribute in the TuningSprout is set properly when the corresponding
         arg is defined in the Namespace.

--- a/test/test_sprouts.py
+++ b/test/test_sprouts.py
@@ -1,0 +1,300 @@
+#! /usr/bin/env python3
+
+# ======================================================================================================================
+# Juneberry - General Release
+#
+# Copyright 2021 Carnegie Mellon University.
+#
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+#
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
+#
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
+#
+# DM21-0884
+#
+# ======================================================================================================================
+from argparse import Namespace
+import logging
+from unittest import TestCase
+
+from juneberry.script_tools.sprout import Sprout
+from juneberry.script_tools.training_sprout import TrainingSprout
+from juneberry.script_tools.tuning_sprout import TuningSprout
+
+
+class TestBaseSprout(TestCase):
+    """
+    Tests meant to exercise the Base Sprout.
+    """
+
+    @staticmethod
+    def build_base_namespace():
+        """
+        This method returns a Namespace. In typical Juneberry scripts, you normally obtain a Namespace
+        by running parse_args() on the ArgumentParser to parse the command line options being passed to
+        the script.
+        :return: A Namespace that sets all of the args expected by the Base Sprout to non-default values.
+        """
+        return Namespace(workspace='workspace_dir',
+                         dataRoot='dataroot_dir',
+                         tensorboard='tensorboard_dir',
+                         logDir='log_dir',
+                         silent=True,
+                         verbose=True,
+                         profileName='profile_name')
+
+    def test_sprout_defaults(self):
+        """
+        This test confirms that all Base Sprout attributes are initialized to None when a Base Sprout
+        is initialized.
+        """
+        # Initialize a Base Sprout.
+        sprout = Sprout()
+
+        # Check all of the Base Sprout attributes.
+        assert sprout.workspace_dir is None
+        assert sprout.dataroot_dir is None
+        assert sprout.tensorboard_dir is None
+        assert sprout.log_dir is None
+        assert sprout.silent is None
+        assert sprout.log_level is None
+        assert sprout.profile_name is None
+
+    def test_sprout_from_empty_namespace(self):
+        """
+        This test checks the behavior of the Base Sprout when an empty Namespace is used to set the
+        attributes in the Base Sprout. For the most attributes, the default values remain the same.
+        """
+        # Initialize a Base Sprout and feed it an empty Namespace.
+        sprout = Sprout()
+        sprout.grow_from_args(Namespace())
+
+        # Check all of the Base Sprout attributes for the expected values.
+        assert sprout.workspace_dir is None
+        assert sprout.dataroot_dir is None
+        assert sprout.tensorboard_dir is None
+        assert sprout.log_dir is None
+        assert sprout.silent is False
+        assert sprout.log_level == logging.INFO
+        assert sprout.profile_name is None
+
+    def test_sprout_base_namespace(self):
+        """
+        This test confirms every attributes in the Base Sprout is set properly when the corresponding
+        arg is defined in the Namespace.
+        """
+        # Initialize a Base Sprout and feed it a fully-defined Namespace.
+        sprout = Sprout()
+        sprout.grow_from_args(self.build_base_namespace())
+
+        # Check all of the Base Sprout attributes for the expected values.
+        assert sprout.workspace_dir == "workspace_dir"
+        assert sprout.dataroot_dir == "dataroot_dir"
+        assert sprout.tensorboard_dir == "tensorboard_dir"
+        assert sprout.log_dir == "log_dir"
+        assert sprout.silent is True
+        assert sprout.log_level == logging.DEBUG
+        assert sprout.profile_name == "profile_name"
+
+
+class TestTrainingSprout(TestCase):
+    """
+    Tests meant to exercise the TrainingSprout.
+    """
+
+    @staticmethod
+    def build_training_namespace():
+        """
+        This method returns a Namespace similar to the Namespace you would received when running jb_train.
+        :return: A Namespace that sets all of the args expected by the TrainingSprout to non-default values.
+        """
+        # Create a Namespace for args that are unique to the TrainingSprout.
+        train_args = Namespace(modelName="test_model",
+                               num_gpus=0,
+                               dryrun=True,
+                               resume=True,
+                               skipNative=True,
+                               onnx=True)
+
+        # Create a Namespace for the args in the Base Sprout.
+        base_args = TestBaseSprout.build_base_namespace()
+
+        # Combine the two Namespaces into a single Namespace and return the result.
+        return Namespace(**vars(train_args), **vars(base_args))
+
+    def test_training_sprout_defaults(self):
+        """
+        This test confirms that all TrainingSprout attributes are initialized to None when a TrainingSprout
+        is initialized.
+        """
+        # Create the sprout.
+        sprout = TrainingSprout()
+
+        # Check the attributes that are unique to the TrainingSprout.
+        assert sprout.model_name is None
+        assert sprout.num_gpus is None
+        assert sprout.dryrun is None
+        assert sprout.resume is None
+        assert sprout.skip_native is None
+        assert sprout.onnx is None
+
+        # Also check the attributes in the base Sprout.
+        assert sprout.workspace_dir is None
+        assert sprout.dataroot_dir is None
+        assert sprout.tensorboard_dir is None
+        assert sprout.log_dir is None
+        assert sprout.silent is None
+        assert sprout.log_level is None
+        assert sprout.profile_name is None
+
+    def test_training_sprout_from_empty_namespace(self):
+        """
+        This test checks the behavior of the Training Sprout when an empty Namespace is used to set the
+        attributes in the Training Sprout.
+        """
+        # Initialize a TrainingSprout and feed it an empty Namespace.
+        sprout = TrainingSprout()
+        sprout.grow_from_args(Namespace())
+
+        # Check all of the attributes that are unique to the TrainingSprout for the expected values.
+        assert sprout.model_name is None
+        assert sprout.num_gpus is None
+        assert sprout.dryrun is False
+        assert sprout.resume is False
+        assert sprout.skip_native is False
+        assert sprout.onnx is False
+
+        # Also check all of the Base Sprout attributes for the expected values.
+        assert sprout.workspace_dir is None
+        assert sprout.dataroot_dir is None
+        assert sprout.tensorboard_dir is None
+        assert sprout.log_dir is None
+        assert sprout.silent is False
+        assert sprout.log_level == logging.INFO
+        assert sprout.profile_name is None
+
+    def test_training_sprout_training_namespace(self):
+        """
+        This test confirms every attributes in the TrainingSprout is set properly when the corresponding
+        arg is defined in the Namespace.
+        """
+        # Initialize a TrainingSprout and feed it a fully-defined Namespace.
+        sprout = TrainingSprout()
+        sprout.grow_from_args(self.build_training_namespace())
+
+        # Check all of the TrainingSprout attributes for the expected values.
+        assert sprout.model_name == "test_model"
+        assert sprout.num_gpus == 0
+        assert sprout.dryrun is True
+        assert sprout.resume is True
+        assert sprout.skip_native is True
+        assert sprout.onnx is True
+
+        # Check all of the Base Sprout attributes for the expected values.
+        assert sprout.workspace_dir == "workspace_dir"
+        assert sprout.dataroot_dir == "dataroot_dir"
+        assert sprout.tensorboard_dir == "tensorboard_dir"
+        assert sprout.log_dir == "log_dir"
+        assert sprout.silent is True
+        assert sprout.log_level == logging.DEBUG
+        assert sprout.profile_name == "profile_name"
+
+
+class TestTuningSprout(TestCase):
+    """
+    Tests meant to exercise the TuningSprout.
+    """
+
+    @staticmethod
+    def build_tuning_namespace():
+        """
+        This method returns a Namespace similar to the Namespace you would received when running jb_tune.
+        :return: A Namespace that sets all of the args expected by the TuningSprout to non-default values.
+        """
+        # Create a Namespace for args that are unique to the TuningSprout.
+        tune_args = Namespace(dryrun=True,
+                              modelName="test_model",
+                              tuningConfig="test_tuning_config")
+
+        # Create a Namespace for the args in the Base Sprout.
+        base_args = TestBaseSprout.build_base_namespace()
+
+        # Combine the two Namespaces into a single Namespace and return the result.
+        return Namespace(**vars(tune_args), **vars(base_args))
+
+    def test_tuning_sprout_defaults(self):
+        """
+        This test confirms that all TuningSprout attributes are initialized to None when a TuningSprout
+        is initialized.
+        """
+        # Create the sprout.
+        sprout = TuningSprout()
+
+        # Check the attributes that are unique to the TuningSprout.
+        assert sprout.dryrun is None
+        assert sprout.model_name is None
+        assert sprout.tuning_config is None
+
+        # Also check the attributes in the base Sprout.
+        assert sprout.workspace_dir is None
+        assert sprout.dataroot_dir is None
+        assert sprout.tensorboard_dir is None
+        assert sprout.log_dir is None
+        assert sprout.silent is None
+        assert sprout.log_level is None
+        assert sprout.profile_name is None
+
+    def test_tuning_sprout_from_empty_namespace(self):
+        """
+        This test checks the behavior of the TuningSprout when an empty Namespace is used to set the
+        attributes in the TuningSprout.
+        """
+        # Initialize a TuningSprout and feed it an empty Namespace.
+        args = Namespace()
+        sprout = TuningSprout()
+        sprout.grow_from_args(args)
+
+        # Check all of the attributes that are unique to the TuningSprout for the expected values.
+        assert sprout.dryrun is False
+        assert sprout.model_name is None
+        assert sprout.tuning_config is None
+
+        # Also check all of the Base Sprout attributes for the expected values.
+        assert sprout.workspace_dir is None
+        assert sprout.dataroot_dir is None
+        assert sprout.tensorboard_dir is None
+        assert sprout.log_dir is None
+        assert sprout.silent is False
+        assert sprout.log_level == logging.INFO
+        assert sprout.profile_name is None
+
+    def test_tuning_sprout_training_namespace(self):
+        """
+        This test confirms every attributes in the TuningSprout is set properly when the corresponding
+        arg is defined in the Namespace.
+        """
+        # Initialize a TuningSprout and feed it a fully-defined Namespace.
+        sprout = TuningSprout()
+        sprout.grow_from_args(self.build_tuning_namespace())
+
+        # Check all of the TuningSprout attributes for the expected values.
+        assert sprout.dryrun is True
+        assert sprout.model_name == "test_model"
+        assert sprout.tuning_config == "test_tuning_config"
+
+        # Check all of the Base Sprout attributes for the expected values.
+        assert sprout.workspace_dir == "workspace_dir"
+        assert sprout.dataroot_dir == "dataroot_dir"
+        assert sprout.tensorboard_dir == "tensorboard_dir"
+        assert sprout.log_dir == "log_dir"
+        assert sprout.silent is True
+        assert sprout.log_level == logging.DEBUG
+        assert sprout.profile_name == "profile_name"

--- a/test/test_sprouts.py
+++ b/test/test_sprouts.py
@@ -88,7 +88,7 @@ class TestBaseSprout(TestCase):
 
     def test_sprout_base_namespace(self):
         """
-        This test confirms every attributes in the Base Sprout is set properly when the corresponding
+        This test confirms every attribute in the Base Sprout is set properly when the corresponding
         arg is defined in the Namespace.
         """
         # Initialize a Base Sprout and feed it a fully-defined Namespace.
@@ -146,7 +146,7 @@ class TestTrainingSprout(TestCase):
         assert sprout.skip_native is None
         assert sprout.onnx is None
 
-        # Also check the attributes in the base Sprout.
+        # Check all of the Base Sprout attributes for the expected values.
         assert sprout.workspace_dir is None
         assert sprout.dataroot_dir is None
         assert sprout.tensorboard_dir is None
@@ -172,7 +172,7 @@ class TestTrainingSprout(TestCase):
         assert sprout.skip_native is False
         assert sprout.onnx is False
 
-        # Also check all of the Base Sprout attributes for the expected values.
+        # Check all of the Base Sprout attributes for the expected values.
         assert sprout.workspace_dir is None
         assert sprout.dataroot_dir is None
         assert sprout.tensorboard_dir is None
@@ -183,7 +183,7 @@ class TestTrainingSprout(TestCase):
 
     def test_training_sprout_training_namespace(self):
         """
-        This test confirms every attributes in the TrainingSprout is set properly when the corresponding
+        This test confirms every attribute in the TrainingSprout is set properly when the corresponding
         arg is defined in the Namespace.
         """
         # Initialize a TrainingSprout and feed it a fully-defined Namespace.
@@ -216,7 +216,7 @@ class TestTuningSprout(TestCase):
     @staticmethod
     def build_tuning_namespace():
         """
-        This method returns a Namespace similar to the Namespace you would received when running jb_tune.
+        This method returns a Namespace similar to the Namespace you would receive when running jb_tune.
         :return: A Namespace that sets all of the args expected by the TuningSprout to non-default values.
         """
         # Create a Namespace for args that are unique to the TuningSprout.
@@ -243,7 +243,7 @@ class TestTuningSprout(TestCase):
         assert sprout.model_name is None
         assert sprout.tuning_config is None
 
-        # Also check the attributes in the base Sprout.
+        # Check all of the Base Sprout attributes for the expected values.
         assert sprout.workspace_dir is None
         assert sprout.dataroot_dir is None
         assert sprout.tensorboard_dir is None
@@ -258,16 +258,15 @@ class TestTuningSprout(TestCase):
         attributes in the TuningSprout.
         """
         # Initialize a TuningSprout and feed it an empty Namespace.
-        args = Namespace()
         sprout = TuningSprout()
-        sprout.grow_from_args(args)
+        sprout.grow_from_args(Namespace())
 
         # Check all of the attributes that are unique to the TuningSprout for the expected values.
         assert sprout.dryrun is False
         assert sprout.model_name is None
         assert sprout.tuning_config is None
 
-        # Also check all of the Base Sprout attributes for the expected values.
+        # Check all of the Base Sprout attributes for the expected values.
         assert sprout.workspace_dir is None
         assert sprout.dataroot_dir is None
         assert sprout.tensorboard_dir is None
@@ -278,7 +277,7 @@ class TestTuningSprout(TestCase):
 
     def test_tuning_sprout_training_namespace(self):
         """
-        This test confirms every attributes in the TuningSprout is set properly when the corresponding
+        This test confirms every attribute in the TuningSprout is set properly when the corresponding
         arg is defined in the Namespace.
         """
         # Initialize a TuningSprout and feed it a fully-defined Namespace.

--- a/test/test_sprouts.py
+++ b/test/test_sprouts.py
@@ -222,7 +222,7 @@ class TestTuningSprout(TestCase):
         # Create a Namespace for args that are unique to the TuningSprout.
         tune_args = Namespace(dryrun=True,
                               modelName="test_model",
-                              tuningConfig="test_tuning_config")
+                              tuningConfig="test_tuning_config.json")
 
         # Create a Namespace for the args in the Base Sprout.
         base_args = TestBaseSprout.build_base_namespace()
@@ -288,7 +288,7 @@ class TestTuningSprout(TestCase):
         # Check all of the TuningSprout attributes for the expected values.
         assert sprout.dryrun is True
         assert sprout.model_name == "test_model"
-        assert sprout.tuning_config == "test_tuning_config"
+        assert sprout.tuning_config == "test_tuning_config.json"
 
         # Check all of the Base Sprout attributes for the expected values.
         assert sprout.workspace_dir == "workspace_dir"

--- a/test/test_trainer_factory.py
+++ b/test/test_trainer_factory.py
@@ -1,0 +1,146 @@
+#! /usr/bin/env python3
+
+# ======================================================================================================================
+# Juneberry - General Release
+#
+# Copyright 2021 Carnegie Mellon University.
+#
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+#
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
+#
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
+#
+# DM21-0884
+#
+# ======================================================================================================================
+from unittest import TestCase
+
+import pytest
+
+from juneberry.config.dataset import DatasetConfig
+from juneberry.config.model import ModelConfig
+from juneberry.detectron2.trainer import Detectron2Trainer
+from juneberry.filesystem import ModelManager
+from juneberry.lab import Lab
+from juneberry.training.trainer_factory import TrainerFactory
+import utils
+
+
+class TestTrainerFactory(TestCase):
+    """
+    This group of tests exercise various aspects of the TrainerFactory.
+    """
+
+    @pytest.fixture(autouse=True)
+    def init_fixtures(self, tmp_path, caplog):
+        """
+        The purpose of this method is to make the pytest tmp_path and caplog fixtures available inside of
+        the unittest.TestCase.
+        """
+        self.tmp_path = tmp_path
+        self.caplog = caplog
+
+        # Initialize a TrainerFactory.
+        self.trainer_factory = TrainerFactory()
+
+        # Set up a workspace with some example files that can be used by the TrainerFactory.
+        with utils.set_directory(self.tmp_path):
+            utils.setup_test_workspace(self.tmp_path)
+            utils.make_dt2_workspace(self.tmp_path)
+
+    def test_trainer_factory_attribute_init(self):
+        """
+        The purpose of this test is to verify that the TrainerFactory attributes are initialized properly.
+        """
+        # Confirm that all TrainerFactory attributes are set to None.
+        assert self.trainer_factory.dataset_config is None
+        assert self.trainer_factory.lab is None
+        assert self.trainer_factory.log_level is None
+        assert self.trainer_factory.model_config is None
+        assert self.trainer_factory.model_manager is None
+
+    def test_trainer_factory_set_model_config(self):
+        """
+        The purpose of this test is to exercise the 'set_model_config' method of the TrainerFactory under
+        various conditions.
+        :return:
+        """
+        # Verify that the TrainerFactory's model_config attribute isn't set.
+        assert self.trainer_factory.model_config is None
+
+        # Attempt to set the model_config attribute. It should fail because currently
+        # there is no ModelManager associated with the TrainerFactory.
+        self.trainer_factory.set_model_config()
+        assert "no ModelManager associated with the TrainerFactory" in self.caplog.text
+
+        # Create a ModelManager and associate it with the TrainerFactory and attempt to
+        # set the model config again.
+        self.trainer_factory.model_manager = ModelManager('text_detect', 'dt2/ut')
+        self.trainer_factory.set_model_config()
+
+        # Verify that the TrainerFactory's model_config attribute has been set and that the
+        # model_config's values match expectations.
+        assert self.trainer_factory.model_config is not None
+        assert self.trainer_factory.model_config.model_architecture.module == "COCO-Detection/faster_rcnn_R_50_FPN_1x.yaml"
+        assert self.trainer_factory.model_config.epochs == 1
+        assert self.trainer_factory.model_config.validation.arguments.seed == 3554237221
+
+        # Create a variation of the previous ModelConfig and make slight adjustments to some of
+        # its attributes.
+        model_config = ModelConfig.load(self.trainer_factory.model_manager.get_model_config())
+        model_config.model_architecture.module = "new_value"
+        model_config.epochs = 10
+        model_config.validation.arguments.seed = 1234
+
+        # Attempt to set the TrainerFactory's model_config attribute to the ModelConfig variation
+        # that was just created.
+        self.trainer_factory.set_model_config(model_config=model_config)
+
+        # Confirm the model_config associated with the TrainerFactory reflects the previously
+        # adjusted values.
+        assert self.trainer_factory.model_config is not None
+        assert self.trainer_factory.model_config.model_architecture.module == "new_value"
+        assert self.trainer_factory.model_config.epochs == 10
+        assert self.trainer_factory.model_config.validation.arguments.seed == 1234
+
+    def test_trainer_factory_get_trainer(self):
+        """
+        The purpose of this test is to exercise the TrainerFactory's ability to produce Trainer objects.
+        """
+        # Verify that the TrainerFactory is unable to produce a Trainer when there is no model
+        # config associated with the TrainerFactory
+        assert self.trainer_factory.model_config is None
+        trainer = self.trainer_factory.get_trainer()
+        assert trainer is None
+
+        # Now set the TrainerFactory attributes which are used to produce Trainers.
+        self.trainer_factory.lab = Lab(workspace=self.tmp_path, data_root=self.tmp_path)
+        self.trainer_factory.model_manager = ModelManager('text_detect', 'dt2/ut')
+        self.trainer_factory.model_config = ModelConfig.load(self.trainer_factory.model_manager.get_model_config())
+        self.trainer_factory.dataset_config = DatasetConfig.load("data_sets/text_detect_val.json")
+
+        # Get a Trainer from the TrainerFactory and verify some of its properties.
+        trainer = self.trainer_factory.get_trainer()
+        assert type(trainer) == Detectron2Trainer
+        assert trainer.resume is False
+        assert trainer.native is True
+        assert trainer.onnx is False
+
+        # Get another Trainer from the TrainerFactory, only this time set the parameters of the
+        # 'get_trainer' method to the opposite of their default values. Verify the type of the
+        # resulting Trainer, and confirm the three Trainer attributes were set correctly.
+        trainer = self.trainer_factory.get_trainer(resume=True, native=False, onnx=True)
+        assert type(trainer) == Detectron2Trainer
+        assert trainer.resume is True
+        assert trainer.native is False
+        assert trainer.onnx is True
+
+

--- a/test/test_tuning.py
+++ b/test/test_tuning.py
@@ -79,7 +79,7 @@ def make_basic_tuning_config():
 def verify_basic_tuning_config(tuning_config: TuningConfig):
     """
     This function examines a TuningConfig object and checks if its attributes match the properties
-    described in JSON content defined above in make_basic_tuning_config().
+    described in the JSON content defined above in make_basic_tuning_config().
     :param tuning_config: The Juneberry TuningConfig object to examine.
     :return: Nothing.
     """
@@ -133,7 +133,7 @@ class TestTuningConfig(TestCase):
         """
         This test exercises construction of a TuningConfig object using a dictionary of data.
         """
-        # Construct the TuningConfig object using the "contents of the JSON file".
+        # Construct the TuningConfig object using a dictionary of data.
         tuning_config = TuningConfig.construct(make_basic_tuning_config())
 
         # Verify the attributes in the TuningConfig.

--- a/test/test_tuning.py
+++ b/test/test_tuning.py
@@ -1,0 +1,318 @@
+#! /usr/bin/env python3
+
+# ======================================================================================================================
+# Juneberry - General Release
+#
+# Copyright 2021 Carnegie Mellon University.
+#
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+#
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
+#
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
+#
+# DM21-0884
+#
+# ======================================================================================================================
+import datetime
+import json
+from pathlib import Path
+from unittest import TestCase
+
+import pytest
+from ray.tune.sample import Categorical as CategoricalSampler
+from ray.tune.schedulers.async_hyperband import AsyncHyperBandScheduler
+from ray.tune.suggest.basic_variant import BasicVariantGenerator
+
+from juneberry.config.tuning import TuningConfig
+import juneberry.config.tuning_output as tuning_output
+from juneberry.script_tools.tuning_sprout import TuningSprout
+from juneberry.tuning.tuner import Tuner
+from test_sprouts import TestTuningSprout
+
+
+def make_basic_tuning_config():
+    """
+    This function returns a dictionary representing the contents of a very basic Juneberry hyperparameter
+    tuning configuration file.
+    """
+    return {
+        "description": "A simple tuning config for unit tests.",
+        "num_samples": 1,
+        "scheduler": {
+            "fqcn": "ray.tune.schedulers.AsyncHyperBandScheduler",
+            "kwargs": {}
+        },
+        "search_algorithm": {
+            "fqcn": "ray.tune.suggest.basic_variant.BasicVariantGenerator",
+            "kwargs": {}
+        },
+        "search_space": [
+            {
+                "hyperparameter_name": "batch_size",
+                "fqcn": "ray.tune.choice",
+                "kwargs": {
+                    "categories": [10, 15]
+                }
+            }
+        ],
+        "trial_resources": {
+            "cpu": 1,
+            "gpu": 0
+        },
+        "tuning_parameters": {
+            "checkpoint_interval": 1,
+            "metric": "loss",
+            "mode": "min",
+            "scope": "last"
+        }
+    }
+
+
+def verify_basic_tuning_config(tuning_config: TuningConfig):
+    """
+    This function examines a TuningConfig object and checks if its attributes match the properties
+    described in JSON content defined above in make_basic_tuning_config().
+    :param tuning_config: The Juneberry TuningConfig object to examine.
+    :return: Nothing.
+    """
+    # Number of samples
+    assert tuning_config.num_samples == 1
+
+    # Scheduler
+    assert tuning_config.scheduler.fqcn == "ray.tune.schedulers.AsyncHyperBandScheduler"
+    assert tuning_config.scheduler.kwargs == {}
+
+    # Search algorithm
+    assert tuning_config.search_algorithm.fqcn == "ray.tune.suggest.basic_variant.BasicVariantGenerator"
+    assert tuning_config.search_algorithm.kwargs == {}
+
+    # Search space
+    assert len(tuning_config.search_space) == 1
+    assert tuning_config.search_space[0].hyperparameter_name == "batch_size"
+    assert tuning_config.search_space[0].fqcn == "ray.tune.choice"
+    assert tuning_config.search_space[0].kwargs == {"categories": [10, 15]}
+
+    # Trial resources
+    assert tuning_config.trial_resources.cpu == 1
+    assert tuning_config.trial_resources.gpu == 0
+
+    # Tuning parameters
+    assert tuning_config.tuning_parameters.checkpoint_interval == 1
+    assert tuning_config.tuning_parameters.metric == "loss"
+    assert tuning_config.tuning_parameters.mode == "min"
+    assert tuning_config.tuning_parameters.scope == "last"
+
+
+class TestTuningConfig(TestCase):
+    """
+    This group of tests exercise various aspects related to Juneberry TuningConfig objects.
+    """
+
+    @pytest.fixture(autouse=True)
+    def init_fixtures(self, tmp_path):
+        """
+        The purpose of this method is to make the pytest tmp_path fixture available inside of
+        the unittest.TestCase.
+        """
+        self.tmp_path = tmp_path
+        self.tuning_config_path = Path(self.tmp_path, "tuning_config.json")
+
+        config = make_basic_tuning_config()
+        with open(self.tuning_config_path, 'w') as out_file:
+            json.dump(config, out_file, indent=4)
+
+    def test_basic_tuning_config_construct(self):
+        """
+        This test exercises construction of a TuningConfig object using a dictionary of data.
+        """
+        # Construct the TuningConfig object using the "contents of the JSON file".
+        tuning_config = TuningConfig.construct(make_basic_tuning_config())
+
+        # Verify the attributes in the TuningConfig.
+        verify_basic_tuning_config(tuning_config)
+
+    def test_basic_tuning_config_load(self):
+        """
+        This test exercises the loading of a TuningConfig from a JSON file.
+        """
+        # Load the TuningConfig data from the JSON file.
+        tuning_config = TuningConfig.load(str(self.tuning_config_path))
+
+        # Verify the attributes in the TuningConfig.
+        verify_basic_tuning_config(tuning_config)
+
+    def test_tuning_config_default_values(self):
+        """
+        This test exercises the setting of default values in the TuningConfig when
+        the parameters aren't present in the input data.
+        """
+        # Start with the basic TuningConfig data.
+        config = make_basic_tuning_config()
+
+        # Remove some fields from the data and confirm that they're gone.
+        del_keys = ["tuning_parameters", "trial_resources"]
+        for key in del_keys:
+            config.pop(key)
+            assert key not in config.keys()
+
+        # Build a TuningConfig object using adjusted data.
+        tuning_config = TuningConfig.construct(config, str(self.tuning_config_path))
+
+        # Confirm the default tuning_parameters have been set.
+        assert tuning_config.tuning_parameters.checkpoint_interval == 0
+        assert tuning_config.tuning_parameters.metric == "loss"
+        assert tuning_config.tuning_parameters.mode == "min"
+        assert tuning_config.tuning_parameters.scope == "last"
+
+        # Confirm the default trial_resources have been set.
+        assert tuning_config.trial_resources.cpu == 1
+        assert tuning_config.trial_resources.gpu == 0
+
+
+class TestTuningOutput(TestCase):
+    """
+    This group of tests exercise various aspects of the output generated during a tuning run.
+    """
+
+    @pytest.fixture(autouse=True)
+    def init_fixtures(self):
+        """
+        The purpose of this method is to establish a TuningOutputBuilder to exercise the ability
+        to produce tuning output data.
+        """
+        self.tuning_output_builder = tuning_output.TuningOutputBuilder()
+        self.output = self.tuning_output_builder.output
+
+    def test_output_init(self):
+        """
+        The purpose of this test is to verify that the tuning output has been initialized
+        correctly.
+        """
+        # Check the attributes of the TuningOutput object.
+        assert self.output.format_version == tuning_output.TuningOutput.FORMAT_VERSION
+        assert type(self.output.options) == tuning_output.Options
+        assert type(self.output.times) == tuning_output.Times
+        assert type(self.output.results) == tuning_output.Results
+        assert self.output.results.trial_results == []
+
+    def test_builder_set_tuning_options(self):
+        """
+        This test exercises the ability to set the tuning options via the TuningOutputBuilder.
+        """
+        # Some strings to use for testing.
+        model_name = "test_model"
+        tuning_config_name = "test_tuning_config.json"
+
+        # Set the tuning options via the TuningOutputBuilder.
+        self.tuning_output_builder.set_tuning_options(model_name=model_name, tuning_config=tuning_config_name)
+
+        # Confirm the options have been set.
+        assert self.output.options.model_name == model_name
+        assert self.output.options.tuning_config == tuning_config_name
+
+    def test_builder_set_times(self):
+        """
+        This test exercises the ability to set the tuning Times via the TuningOutputBuilder.
+        """
+        # Create some timestamps.
+        start_time = datetime.datetime.now().replace(microsecond=0)
+        end_time = datetime.datetime.now().replace(microsecond=0)
+
+        # Set the timing information in the tuning output.
+        self.tuning_output_builder.set_times(start_time=start_time, end_time=end_time)
+
+        # Verify the start time, end time, and duration have been set properly in the tuning output.
+        assert self.output.times.start_time == start_time.isoformat()
+        assert self.output.times.end_time == end_time.isoformat()
+        assert self.output.times.duration == (end_time - start_time).total_seconds()
+
+    def test_builder_append_trial_result(self):
+        """
+        This test exercises the ability to append trial data to the Results section of the tuning output.
+        """
+        # Create some data to feed into the TuningOutputBuilder.
+        directory = "test_dirname"
+        params = {"batch_size": 10}
+        trial_data = [
+            {"trial_id": "abc_123", "loss": 10, "accuracy": 0.1, "lr": 0.01},
+            {"trial_id": "abc_123", "loss": 5, "accuracy": 0.2, "lr": 0.001}
+        ]
+
+        # Use the sample data to append a trial result to the tuning output.
+        self.tuning_output_builder.append_trial_result(directory=directory, params=params, trial_data=trial_data)
+
+        # Verify the trial result has been set properly.
+        assert self.output.results.trial_results == [
+            {
+                "directory": "test_dirname",
+                "id": "abc_123",
+                "num_iterations": 2,
+                "params": {"batch_size": 10},
+                "result_data": {
+                    "trial_id": ['abc_123', 'abc_123'],
+                    "loss": [10, 5],
+                    "accuracy": [0.1, 0.2],
+                    "lr": [0.01, 0.001]
+                }
+            }
+        ]
+
+
+class TestTuner(TestCase):
+    """
+    This group of tests exercise various aspects related to performing hyperparameter tuning using a
+    Juneberry Tuner.
+    """
+
+    def test_simple_tuner_setup(self):
+        """
+        This test exercises basic functionality of the Juneberry Tuner.
+        """
+        # Initialize the Tuner.
+        tuner = Tuner()
+
+        # Confirm the default values for all Tuner attributes.
+        assert tuner.trainer_factory is None
+        assert tuner.sprout is None
+        assert tuner.tuning_config is None
+        assert tuner.search_space is None
+        assert tuner.search_algo is None
+        assert tuner.scheduler is None
+        assert tuner.best_result is None
+        assert type(tuner.output_builder) == tuning_output.TuningOutputBuilder
+        assert type(tuner.output) == tuning_output.TuningOutput
+        assert tuner.tuning_start_time is None
+        assert tuner.tuning_end_time is None
+
+        # Construct a TuningConfig and associate it with the Tuner.
+        tuner.tuning_config = TuningConfig.construct(make_basic_tuning_config())
+
+        # Construct a TuningSprout, associate it with the Tuner, and add data to the Sprout.
+        tuner.sprout = TuningSprout()
+        tuner.sprout.grow_from_args(TestTuningSprout.build_tuning_namespace())
+
+        # Now perform a tuning dryrun using the Tuner.
+        tuner.tune(dryrun=True)
+
+        # Confirm the model name and tuning config name were set correctly in the tuning output.
+        assert tuner.output.options.model_name == "test_model"
+        assert tuner.output.options.tuning_config == "test_tuning_config.json"
+
+        # Confirm the Tuner's search space was set up correctly.
+        assert tuner.search_space is not None
+        assert 'batch_size' in tuner.search_space.keys()
+        assert type(tuner.search_space['batch_size']) == CategoricalSampler
+
+        # Confirm the Tuner's scheduler was set up correctly.
+        assert type(tuner.scheduler) is AsyncHyperBandScheduler
+
+        # Confirm the Tuner's search algorithm was set up correctly.
+        assert type(tuner.search_algo) is BasicVariantGenerator

--- a/test/utils.py
+++ b/test/utils.py
@@ -164,13 +164,13 @@ def setup_test_workspace(tmp_path) -> None:
     ws_path = Path(tmp_path)
     model_dir_path = ws_path / "models"
     tbs_dir_path = model_dir_path / "tabular_binary_sample"
-    tbs_dir_path.mkdir(parents=True)
+    tbs_dir_path.mkdir(parents=True, exist_ok=True)
 
     dt_conf_path = model_dir_path / "text_detect" / "dt2" / "ut"
-    dt_conf_path.mkdir(parents=True)
+    dt_conf_path.mkdir(parents=True, exist_ok=True)
 
     data_sets_path = ws_path / "data_sets"
-    data_sets_path.mkdir()
+    data_sets_path.mkdir(exist_ok=True)
 
 
 def make_tabular_workspace(tmp_path) -> None:


### PR DESCRIPTION
The majority of this PR involves new units tests which exercise various aspects that were introduced during the hyperparameter tuning feature.

I also added a dryrun mode to the Tuner, which just bails from the Tuner just prior to starting the model tuning.

I also snuck in a Table of Contents into a specification file. Dominique recommended the addition and the change didn't feel substantial enough to merit its own PR.