### PR TITLE
fixes to replace_fc

### DIFF
--- a/juneberry/pytorch/model_transforms.py
+++ b/juneberry/pytorch/model_transforms.py
@@ -26,6 +26,8 @@ import logging
 from pathlib import Path
 import sys
 
+from functools import reduce
+
 import torch
 from torchsummary import summary
 
@@ -213,13 +215,29 @@ class ReplaceFC:
         self.num_classes = num_classes
         self.fc_name = fc_name
         self.fc_bias = fc_bias
-    
+        
+    def get_module_by_name(self, module, access_string):
+        names = access_string.split(sep='.')
+        return reduce(getattr, names, module)
+
+    def set_module_by_name(self, module, access_string, value):
+        names = access_string.split(sep='.')
+        x = module
+        for (i, name) in enumerate(names):
+            if (i == len(names)-1):
+                x = setattr( x, name, value )
+            else:
+                x = getattr( x, name )
+        return module
+
     def __call__(self, model):
-        original_layer = getattr(model, self.fc_name)
+        
+        # Find the last linear layer
+        original_layer = self.get_module_by_name(model, self.fc_name) 
         in_features = original_layer.in_features
         new_layer = torch.nn.modules.linear.Linear(in_features=in_features, out_features=self.num_classes,
                                                    bias=self.fc_bias)
-        setattr(model, self.fc_name, new_layer)
+        model = self.set_module_by_name(model, self.fc_name, new_layer)
         
         return model
 


### PR DESCRIPTION
Generalizes replace fc to take a names that descend into sequential containers, i.e. one with dots, such as used by the egg architectures. 