### PR TITLE
Fixed some issues related to generating experiment rules for reports

### DIFF
--- a/bin/jb_experiment_to_rules
+++ b/bin/jb_experiment_to_rules
@@ -263,7 +263,7 @@ class RuleMaker:
                     cmd_id = workflow.add_rule(inputs, outputs, command, doc, clean_extras, requirements)
 
                     # Dry run rule
-                    workflow = self.builder.get_workflow("dryrun")
+                    dryrun_workflow = self.builder.get_workflow("dryrun")
                     if model.train:
                         inputs = [test.dataset_path]
                     else:
@@ -293,8 +293,8 @@ class RuleMaker:
                         requirements = []
 
                     # Add a temporary property for now
-                    model['dryrun_rule_id'] = workflow.add_rule(inputs, outputs, command, doc, clean_extras,
-                                                                requirements)
+                    model['dryrun_rule_id'] = dryrun_workflow.add_rule(inputs, outputs, command, doc, clean_extras,
+                                                                       requirements)
 
                     # Save the rule id and file for the report
                     eval_dir_mgr = model_mgr.get_eval_dir_mgr(test.dataset_path)


### PR DESCRIPTION
The PR addresses the following issues when generating experiment rules for report:

- Resolved a recursive dependency error for custom report types
- Cleaned up the inputs list for the Summary report type
- Addressed a bug where experiment eval rules were being sent to the wrong workflow in situations where a model was slated for multiple evals.