### PR TITLE
JB-444 wire in model zoo

### DIFF
--- a/bin/jb_evaluate
+++ b/bin/jb_evaluate
@@ -131,7 +131,8 @@ def main():
         log_file=log_file,
         log_prefix=jb_scripting.standard_line_prefix(args.dryrun),
         model_name=model_name,
-        banner_msg=">>> Juneberry Evaluator <<<")
+        banner_msg=">>> Juneberry Evaluator <<<",
+        download=True)
 
     # Show the abbreviated platform info
     logger.info(f"Platform Info: {juneberry.platform_info.make_minimum_report()}")
@@ -155,39 +156,39 @@ def main():
 
     if evaluator is None:
         logger.error(f"No Evaluator instantiated. Exiting.")
+        return
 
+    if args.dryrun:
+        # Perform the dry run for the Evaluator.
+        evaluator.dry_run()
+        return
+
+    # If we got this far, perform the evaluation.
+    evaluator.num_gpus = evaluator.check_gpu_availability(lab.profile.num_gpus)
+    if eval_dir_mgr.predictions_exists() and args.skip_exists:
+        logger.info(f"--skip-exists is true and {eval_dir_mgr.get_predictions_path()} found. Skipping.")
     else:
-        if args.dryrun:
-            # Perform the dry run for the Evaluator.
-            evaluator.dry_run()
+        evaluator.perform_evaluation()
 
-        else:
-            # Perform the evaluation.
-            evaluator.num_gpus = evaluator.check_gpu_availability(lab.profile.num_gpus)
+    # EXPERIMENTAL
+    if len(args.dataset) > 1:
+        for dsname in args.dataset[1:]:
+            # Try to reset the dataset file, reinit logging, and attempt another eval.
+            eval_dir_mgr = model_manager.get_eval_dir_mgr(dsname)
+            eval_dir_mgr.setup()
+            jb_logging.setup_logger(log_file=eval_dir_mgr.get_log_path(args.dryrun),
+                                    log_prefix=jb_scripting.standard_line_prefix(args.dryrun),
+                                    log_to_console=False,
+                                    level=level)
+
+            dataset = lab.load_dataset_config(dsname)
             if eval_dir_mgr.predictions_exists() and args.skip_exists:
                 logger.info(f"--skip-exists is true and {eval_dir_mgr.get_predictions_path()} found. Skipping.")
             else:
-                evaluator.perform_evaluation()
+                evaluator.perform_additional_eval(eval_dir_mgr.get_log_path(args.dryrun), dataset,
+                                                  eval_dir_mgr, dryrun=args.dryrun)
 
-            # EXPERIMENTAL
-            if len(args.dataset) > 1:
-                for dsname in args.dataset[1:]:
-                    # Try to reset the dataset file, reinit logging, and attempt another eval.
-                    eval_dir_mgr = model_manager.get_eval_dir_mgr(dsname)
-                    eval_dir_mgr.setup()
-                    jb_logging.setup_logger(log_file=eval_dir_mgr.get_log_path(args.dryrun),
-                                            log_prefix=jb_scripting.standard_line_prefix(args.dryrun),
-                                            log_to_console=False,
-                                            level=level)
-
-                    dataset = lab.load_dataset_config(dsname)
-                    if eval_dir_mgr.predictions_exists() and args.skip_exists:
-                        logger.info(f"--skip-exists is true and {eval_dir_mgr.get_predictions_path()} found. Skipping.")
-                    else:
-                        evaluator.perform_additional_eval(eval_dir_mgr.get_log_path(args.dryrun), dataset,
-                                                          eval_dir_mgr, dryrun=args.dryrun)
-
-            logger.info(f"jb_evaluate is done.")
+    logger.info(f"jb_evaluate is done.")
 
 
 if __name__ == "__main__":

--- a/docs/zoo.md
+++ b/docs/zoo.md
@@ -1,0 +1,37 @@
+Workspace and Experiment Overview
+==========
+
+# Introduction
+
+Juneberry supports the idea of a model zoo where config files and pre-trained models can be downloaded.
+Model zoo files are stored on remote servers in a hierarchy similar to how the models directory is
+constructed. Given a path to a zoo file of:
+
+"https://junebery.com/models/my-model/resnet.zip"
+
+- https://juneberry.com/models - The base url to where models are stored on the server.
+- my-model/resnet18.zip - A zip containing the model for the model "my-model/resnet18"
+
+# Packaging a model
+
+The contents of the zip file are the important contents of the model that is to be shared. This is usually
+
+- config.json
+- model.pt or model.h5
+- (optional) hashes.json
+
+If desired the hashes.json can be provided indicating what specific model architecture was used to generate
+this model. If this file exists and the model_architecture hash embdedded insides does NOT match the hash of 
+locally constructred model architecture summary, then the model will not be loaded and an error is generated.
+During training the "hashes-latest.json" file is generted which contains the model_architecture hash that was
+used to train the model
+
+A convenience tool is provided that will package up the zip file. To invoke specify the model and a directory
+that represents a staging are for the zoo where the zip files is to be run. The tool is expected to be run from
+the roots of the worksapce.  For exampe
+
+`python -m juneberry.zoo my-model/resnet18 ./zoo-staging`
+
+This command would create the file "./zoo-staging/my-model/resnet18.zip" that contains the config file, the 
+model.pt (asuming this is a PyTorch model) and would have added in hashes.json (if exists) or a renamed copy 
+of "hashes-latest.json" if it exists and "hashes.json" doesn't.

--- a/docs/zoo.md
+++ b/docs/zoo.md
@@ -1,37 +1,38 @@
-Workspace and Experiment Overview
+Model Zoo Overview
 ==========
 
 # Introduction
 
-Juneberry supports the idea of a model zoo where config files and pre-trained models can be downloaded.
-Model zoo files are stored on remote servers in a hierarchy similar to how the models directory is
-constructed. Given a path to a zoo file of:
+Juneberry supports the idea of a model zoo, which contains config files and pre-trained models that 
+can be downloaded and used in Juneberry. Model zoo files are stored on remote servers in a hierarchy 
+similar to how the 'models' directory is organized. Consider the following path to a zoo file:
 
-"https://junebery.com/models/my-model/resnet.zip"
+"https://juneberry.com/models/my-model/resnet.zip"
 
-- https://juneberry.com/models - The base url to where models are stored on the server.
-- my-model/resnet18.zip - A zip containing the model for the model "my-model/resnet18"
+- https://juneberry.com/models - The base url of the server where the models are stored.
+- my-model/resnet18.zip - A zip containing the model named "my-model/resnet18".
 
 # Packaging a model
 
-The contents of the zip file are the important contents of the model that is to be shared. This is usually
+The model zip file contains any necessary files required to share the model. These typically include the 
+following:
 
 - config.json
 - model.pt or model.h5
 - (optional) hashes.json
 
-If desired the hashes.json can be provided indicating what specific model architecture was used to generate
-this model. If this file exists and the model_architecture hash embdedded insides does NOT match the hash of 
-locally constructred model architecture summary, then the model will not be loaded and an error is generated.
-During training the "hashes-latest.json" file is generted which contains the model_architecture hash that was
-used to train the model
+When provided, the hashes.json file can confirm which model architecture was used to generate
+the model. If the model_architecture hash embedded inside the hashes.json does NOT match the hash of 
+locally constructed model architecture summary, then the model will not be loaded from the zoo and an 
+error is generated. During training, a "hashes-latest.json" file will be produced which contains the 
+model_architecture hash that was used to train the model.
 
-A convenience tool is provided that will package up the zip file. To invoke specify the model and a directory
-that represents a staging are for the zoo where the zip files is to be run. The tool is expected to be run from
-the roots of the worksapce.  For exampe
+A convenience tool is provided which packages up the zip file. To invoke the tool, specify the model and 
+a directory representing a staging area for zip files to be uploaded to the zoo. The tool expects to be run from
+the root of the workspace. Consider the following command:
 
 `python -m juneberry.zoo my-model/resnet18 ./zoo-staging`
 
-This command would create the file "./zoo-staging/my-model/resnet18.zip" that contains the config file, the 
-model.pt (asuming this is a PyTorch model) and would have added in hashes.json (if exists) or a renamed copy 
-of "hashes-latest.json" if it exists and "hashes.json" doesn't.
+This command would create the file "./zoo-staging/my-model/resnet18.zip" containing the model's config file, the 
+model.pt (assuming it is a PyTorch model), and a hashes.json file (if one exists) or a copy 
+of "hashes-latest.json", if one exists, renamed to "hashes.json".

--- a/juneberry/config/hashes.py
+++ b/juneberry/config/hashes.py
@@ -1,0 +1,85 @@
+#! /usr/bin/env python3
+
+# ======================================================================================================================
+# Juneberry - General Release
+#
+# Copyright 2021 Carnegie Mellon University.
+#
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS"
+# BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER
+# INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED
+# FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM
+# FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#
+# Released under a BSD (SEI)-style license, please see license.txt or contact permission@sei.cmu.edu for full terms.
+#
+# [DISTRIBUTION STATEMENT A] This material has been approved for public release and unlimited distribution.  Please see
+# Copyright notice for non-US Government use and distribution.
+#
+# This Software includes and/or makes use of Third-Party Software subject to its own license.
+#
+# DM21-0884
+#
+# ======================================================================================================================
+
+import logging
+from pathlib import Path
+import sys
+
+from prodict import Prodict, List
+
+from juneberry.config.plugin import Plugin
+import juneberry.config.util as jb_conf_utils
+import juneberry.filesystem as jb_fs
+
+logger = logging.getLogger(__name__)
+
+
+class Hashes(Prodict):
+    FORMAT_VERSION = '0.3.0'
+    SCHEMA_NAME = 'hashes_schema.json'
+
+    model_architecture: str
+
+    @staticmethod
+    def construct(data: dict, file_path: str = None):
+        """
+        Validate and construct a Hashes object.
+        :param data: The data to use to construct the object.
+        :param file_path: Optional path to a file that may have been loaded. Used for logging.
+        :return: A constructed object.
+        """
+
+        # Validate with our schema
+        if not jb_conf_utils.validate_schema(data, Hashes.SCHEMA_NAME):
+            logger.error(f"Validation errors in DatasetConfig from {file_path}. See log. EXITING!")
+            sys.exit(-1)
+
+        # Finally, construct the object
+        return Hashes.from_dict(data)
+
+    @staticmethod
+    def load(data_path: str):
+        """
+        Load the config from the provided path, validate and construct the config.
+        :param data_path: Path to config.
+        :return: Loaded, validated, and constructed object.
+        """
+        # Load the raw file.
+        logger.info(f"Loading HASHES CONFIG from {data_path}")
+        data = jb_fs.load_file(data_path)
+
+        # Validate and construct the model.
+        return Hashes.construct(data, data_path)
+
+    def to_json(self):
+        """ :return: A pure dictionary version suitable for serialization to json."""
+        return jb_conf_utils.prodict_to_dict(self)
+
+    def save(self, data_path: str) -> None:
+        """
+        Save the DatasetConfig to the specified resource path.
+        :param data_path: The path to the resource.
+        :return: None
+        """
+        jb_conf_utils.validate_and_save_json(self.to_json(), data_path, Hashes.SCHEMA_NAME)

--- a/juneberry/config/hashes.py
+++ b/juneberry/config/hashes.py
@@ -23,12 +23,10 @@
 # ======================================================================================================================
 
 import logging
-from pathlib import Path
 import sys
 
-from prodict import Prodict, List
+from prodict import Prodict
 
-from juneberry.config.plugin import Plugin
 import juneberry.config.util as jb_conf_utils
 import juneberry.filesystem as jb_fs
 
@@ -52,7 +50,7 @@ class Hashes(Prodict):
 
         # Validate with our schema
         if not jb_conf_utils.validate_schema(data, Hashes.SCHEMA_NAME):
-            logger.error(f"Validation errors in DatasetConfig from {file_path}. See log. EXITING!")
+            logger.error(f"Validation errors in Hashes object from {file_path}. See log. Exiting!")
             sys.exit(-1)
 
         # Finally, construct the object
@@ -61,7 +59,7 @@ class Hashes(Prodict):
     @staticmethod
     def load(data_path: str):
         """
-        Load the config from the provided path, validate and construct the config.
+        Load the config from the provided path, validate, and construct the config.
         :param data_path: Path to config.
         :return: Loaded, validated, and constructed object.
         """
@@ -78,7 +76,7 @@ class Hashes(Prodict):
 
     def save(self, data_path: str) -> None:
         """
-        Save the DatasetConfig to the specified resource path.
+        Save the HashesConfig to the specified resource path.
         :param data_path: The path to the resource.
         :return: None
         """

--- a/juneberry/filesystem.py
+++ b/juneberry/filesystem.py
@@ -707,9 +707,13 @@ class ModelManager:
         """ :return: The path to model summary file. """
         return self.model_dir_path / 'model_summary.txt'
 
+    def get_model_config_filename(self):
+        """ :return: The path to the model's config file. """
+        return 'config.json'
+
     def get_model_config(self):
         """ :return: The path to the model's config file. """
-        return self.model_dir_path / 'config.json'
+        return self.model_dir_path / self.get_model_config_filename()
 
     def get_known_results(self):
         """ :return: The path to the model's known results file. """
@@ -718,6 +722,21 @@ class ModelManager:
     def get_latest_results(self):
         """ :return: The path to the model's latest results file. """
         return self.model_dir_path / 'latest_ut_results.json'
+
+    def get_hashes_config_filename(self):
+        """ :return: The path to the optional hashes config file. """
+        return 'hashes.json'
+
+    def get_hashes_config(self):
+        """ :return: The path to the optional hashes config file. """
+        return self.model_dir_path / self.get_hashes_config_filename()
+
+    def get_latest_hashes_config_filename(self):
+        return 'hashes-latest.json'
+
+    def get_latest_hashes_config(self):
+        """ :return: The path to the optional hashes config file. """
+        return self.model_dir_path / self.get_latest_hashes_config_filename()
 
     # ============ TRAINING ============
 

--- a/juneberry/filesystem.py
+++ b/juneberry/filesystem.py
@@ -723,7 +723,7 @@ class ModelManager:
         """ :return: The path to the model's latest results file. """
         return self.model_dir_path / 'latest_ut_results.json'
 
-    def get_hashes_config_filename(self):
+    def get_hashes_config_filename(self) -> str:
         """ :return: The path to the optional hashes config file. """
         return 'hashes.json'
 
@@ -731,11 +731,12 @@ class ModelManager:
         """ :return: The path to the optional hashes config file. """
         return self.model_dir_path / self.get_hashes_config_filename()
 
-    def get_latest_hashes_config_filename(self):
+    def get_latest_hashes_config_filename(self) -> str:
+        """ :return: The file name of the latest (generated) optional hashes config file. """
         return 'hashes-latest.json'
 
     def get_latest_hashes_config(self):
-        """ :return: The path to the optional hashes config file. """
+        """ :return: The path to the latest (generated)  optional hashes config file. """
         return self.model_dir_path / self.get_latest_hashes_config_filename()
 
     # ============ TRAINING ============

--- a/juneberry/filesystem.py
+++ b/juneberry/filesystem.py
@@ -708,7 +708,7 @@ class ModelManager:
         return self.model_dir_path / 'model_summary.txt'
 
     def get_model_config_filename(self):
-        """ :return: The path to the model's config file. """
+        """ :return: The filename of the model config. """
         return 'config.json'
 
     def get_model_config(self):
@@ -724,19 +724,19 @@ class ModelManager:
         return self.model_dir_path / 'latest_ut_results.json'
 
     def get_hashes_config_filename(self) -> str:
-        """ :return: The path to the optional hashes config file. """
+        """ :return: The filename of the (optional) hashes config file. """
         return 'hashes.json'
 
     def get_hashes_config(self):
-        """ :return: The path to the optional hashes config file. """
+        """ :return: The path to the (optional) hashes config file. """
         return self.model_dir_path / self.get_hashes_config_filename()
 
     def get_latest_hashes_config_filename(self) -> str:
-        """ :return: The file name of the latest (generated) optional hashes config file. """
+        """ :return: The filename of the latest (generated) optional hashes config file. """
         return 'hashes-latest.json'
 
     def get_latest_hashes_config(self):
-        """ :return: The path to the latest (generated)  optional hashes config file. """
+        """ :return: The path to the latest (generated) optional hashes config file. """
         return self.model_dir_path / self.get_latest_hashes_config_filename()
 
     # ============ TRAINING ============

--- a/juneberry/pytorch/evaluation/evaluator.py
+++ b/juneberry/pytorch/evaluation/evaluator.py
@@ -42,6 +42,7 @@ import juneberry.pytorch.processing as processing
 import juneberry.pytorch.utils as pyt_utils
 from juneberry.pytorch.utils import PyTorchPlatformDefinitions
 from juneberry.transforms.transform_manager import TransformManager
+import juneberry.zoo as jb_zoo
 
 logger = logging.getLogger(__name__)
 
@@ -291,6 +292,14 @@ class Evaluator(EvaluatorBase):
 
         # If the model file exists, load the weights.
         if model_path.exists():
+            # Check to see if we can load it
+            image_shape = pyt_utils.get_image_shape(self.eval_loader)
+            if not jb_zoo.check_allow_load_model(self.model_manager,
+                                             lambda: pyt_utils.hash_summary(self.model, image_shape)):
+                logger.error("Cannot load model because of ARCHITECTURE hash mismatch. "
+                             "Either delete the hash, retrain or get the correct model. Exiting")
+                raise RuntimeError("Model architecture does not match hash. See log for details.")
+
             logger.info(f"Loading model weights...")
             self.model = pyt_utils.load_model(model_path, self.model, self.model_config.pytorch.strict)
 

--- a/juneberry/pytorch/evaluation/evaluator.py
+++ b/juneberry/pytorch/evaluation/evaluator.py
@@ -292,12 +292,12 @@ class Evaluator(EvaluatorBase):
 
         # If the model file exists, load the weights.
         if model_path.exists():
-            # Check to see if we can load it
+            # Check to see if we can load it.
             image_shape = pyt_utils.get_image_shape(self.eval_loader)
             if not jb_zoo.check_allow_load_model(self.model_manager,
-                                             lambda: pyt_utils.hash_summary(self.model, image_shape)):
+                                                 lambda: pyt_utils.hash_summary(self.model, image_shape)):
                 logger.error("Cannot load model because of ARCHITECTURE hash mismatch. "
-                             "Either delete the hash, retrain or get the correct model. Exiting")
+                             "Either delete the hash, retrain or get the correct model. Exiting.")
                 raise RuntimeError("Model architecture does not match hash. See log for details.")
 
             logger.info(f"Loading model weights...")

--- a/juneberry/pytorch/trainer.py
+++ b/juneberry/pytorch/trainer.py
@@ -365,7 +365,7 @@ class ClassifierTrainer(EpochTrainer):
         logger.info("Generating summary plot...")
         juneberry.plotting.plot_training_summary_chart(self.results, self.model_manager)
 
-        logger.info("Updating model_architecture hash")
+        logger.info("Updating model_architecture hash...")
         self._updated_hashes()
 
     # ==========================================================================
@@ -553,7 +553,7 @@ class ClassifierTrainer(EpochTrainer):
 
     def _updated_hashes(self):
         # If we have an existing hash file, update it.
-        # Always update 'latest' as it is what we use when package a model for the zoo.
+        # Always update 'latest' as it is what gets used when packaging a model for the zoo.
         image_shape = pyt_utils.get_image_shape(self.training_iterable)
         model_arch_hash = pyt_utils.hash_summary(self.model, image_shape)
         jb_zoo.update_hashes_after_training(self.model_manager, model_arch_hash)

--- a/juneberry/pytorch/trainer.py
+++ b/juneberry/pytorch/trainer.py
@@ -48,6 +48,7 @@ from juneberry.pytorch.utils import PyTorchPlatformDefinitions
 import juneberry.tensorboard as jb_tb
 from juneberry.training.trainer import EpochTrainer
 from juneberry.transforms.transform_manager import TransformManager
+import juneberry.zoo as jb_zoo
 
 logger = logging.getLogger(__name__)
 
@@ -364,6 +365,9 @@ class ClassifierTrainer(EpochTrainer):
         logger.info("Generating summary plot...")
         juneberry.plotting.plot_training_summary_chart(self.results, self.model_manager)
 
+        logger.info("Updating model_architecture hash")
+        self._updated_hashes()
+
     # ==========================================================================
 
     def check_gpu_availability(self, required: int = None):
@@ -544,6 +548,15 @@ class ClassifierTrainer(EpochTrainer):
         else:
             logger.error(f"acceptance_comparator requires a direction of 'ge' or 'le'.")
             sys.exit(-1)
+
+    # ==========================================================================
+
+    def _updated_hashes(self):
+        # If we have an existing hash file, update it.
+        # Always update 'latest' as it is what we use when package a model for the zoo.
+        image_shape = pyt_utils.get_image_shape(self.training_iterable)
+        model_arch_hash = pyt_utils.hash_summary(self.model, image_shape)
+        jb_zoo.update_hashes_after_training(self.model_manager, model_arch_hash)
 
 
 # ==================================================================================================

--- a/juneberry/pytorch/utils.py
+++ b/juneberry/pytorch/utils.py
@@ -432,24 +432,24 @@ def output_summary_file(model, image_shape, summary_file_path) -> None:
 def hash_summary(model, image_shape):
     """
     Returns a digest (hash) of the model summary file.
-    :param model: The model to hash
+    :param model: The model to hash.
     :param image_shape: The shape of the model.
-    :return: The digest
+    :return: The digest.
     """
 
-    # Swap out a string buffer, and capture the summary to it
+    # Swap out a string buffer and capture the summary in the buffer.
     output = io.StringIO()
     orig = sys.stdout
     sys.stdout = output
     summary(model, image_shape)
     sys.stdout = orig
 
-    # Hash it and stash off the digest before we destroy the buffer
+    # Hash the model summary and stash off the digest before destroying the buffer.
     hasher = hashlib.sha256()
     hasher.update(output.getvalue().encode('utf-8'))
     digest = hasher.hexdigest()
 
-    # Close object and discard memory buffer
+    # Close the object and discard the memory buffer.
     output.close()
 
     return digest
@@ -465,9 +465,9 @@ def un_normalize_imagenet_norms(x):
 
 def get_image_shape(data_loader):
     """
-    Returns the shape of the first item in the loader.  We assume they are all the same.
+    Returns the shape of the first item in the loader. All inputs are assumed to be the same size.
     :param data_loader: The data loader to examine.
-    :return: The image shape
+    :return: The image shape.
     """
     # We need the first item and first part (image)
     return next(iter(data_loader))[0][0].shape

--- a/juneberry/pytorch/utils.py
+++ b/juneberry/pytorch/utils.py
@@ -23,6 +23,8 @@
 # ======================================================================================================================
 
 from collections import namedtuple
+import hashlib
+import io
 import logging
 from pathlib import Path
 import random
@@ -427,12 +429,48 @@ def output_summary_file(model, image_shape, summary_file_path) -> None:
     sys.stdout = orig
 
 
+def hash_summary(model, image_shape):
+    """
+    Returns a digest (hash) of the model summary file.
+    :param model: The model to hash
+    :param image_shape: The shape of the model.
+    :return: The digest
+    """
+
+    # Swap out a string buffer, and capture the summary to it
+    output = io.StringIO()
+    orig = sys.stdout
+    sys.stdout = output
+    summary(model, image_shape)
+    sys.stdout = orig
+
+    # Hash it and stash off the digest before we destroy the buffer
+    hasher = hashlib.sha256()
+    hasher.update(output.getvalue().encode('utf-8'))
+    digest = hasher.hexdigest()
+
+    # Close object and discard memory buffer
+    output.close()
+
+    return digest
+
+
 def un_normalize_imagenet_norms(x):
     # TODO: Generalize to arbitrary values and numbers of channels 
     x_r = x[0, :, :] * 0.229 + 0.485
     x_g = x[1, :, :] * 0.224 + 0.456
     x_b = x[2, :, :] * 0.225 + 0.406
     return torch.stack([x_r, x_g, x_b])
+
+
+def get_image_shape(data_loader):
+    """
+    Returns the shape of the first item in the loader.  We assume they are all the same.
+    :param data_loader: The data loader to examine.
+    :return: The image shape
+    """
+    # We need the first item and first part (image)
+    return next(iter(data_loader))[0][0].shape
 
 
 def generate_sample_images(data_loader, quantity, img_path: Path):

--- a/juneberry/schemas/hashes_schema.json
+++ b/juneberry/schemas/hashes_schema.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "description": "A configuration storing model hashes",
+    "properties": {
+        "model_architecture": { "type" :  "string"}
+    }
+}

--- a/juneberry/schemas/hashes_schema.json
+++ b/juneberry/schemas/hashes_schema.json
@@ -2,6 +2,6 @@
     "$schema": "https://json-schema.org/draft-07/schema",
     "description": "A configuration storing model hashes",
     "properties": {
-        "model_architecture": { "type" :  "string"}
+        "model_architecture": { "type" :  "string" }
     }
 }

--- a/juneberry/scripting/utils.py
+++ b/juneberry/scripting/utils.py
@@ -31,6 +31,7 @@ import sys
 
 import juneberry.logging as jb_logging
 from juneberry.lab import Lab
+import juneberry.zoo as jb_zoo
 
 logger = logging.getLogger(__name__)
 
@@ -237,6 +238,8 @@ def setup_workspace(args, *, log_file, log_prefix="", name="juneberry", banner_m
     logger.info(f"Using data root:    {lab.data_root()}")
     logger.info(f"Using tensorboard:  {lab.tensorboard}")
     logger.info(f"Using profile name: {lab.profile_name}")
+    logger.info(f"Using zoo:          {lab.model_zoo}")
+    logger.info(f"Using cache:        {lab.cache}")
     logger.info(f"Hostname:           {platform.uname().node}")
 
     return lab
@@ -267,12 +270,19 @@ def setup_logging_for_script(args, script_name: str = None):
     logger.info(f"Log messages are beings saved to {log_file}")
 
 
-def setup_workspace_and_model(args, *, log_file, model_name, log_prefix="", banner_msg=None):
+def setup_workspace_and_model(args, *, log_file, model_name, log_prefix="", banner_msg=None,
+                              download:bool = False):
     # Setup up the workspace like normal
     lab = setup_workspace(args, log_file=log_file, log_prefix=log_prefix, banner_msg=banner_msg)
 
     # Double check the model.
     mm = lab.model_manager(model_name)
+    if not mm.get_model_config().exists() and download:
+        # See if we can use the zoo
+        jb_zoo.ensure_model(lab, model_name)
+
+    # Now, the model should be there or have failed
     mm.ensure_model_directory()
     mm.setup()
     return lab
+

--- a/juneberry/scripting/utils.py
+++ b/juneberry/scripting/utils.py
@@ -271,18 +271,17 @@ def setup_logging_for_script(args, script_name: str = None):
 
 
 def setup_workspace_and_model(args, *, log_file, model_name, log_prefix="", banner_msg=None,
-                              download:bool = False):
+                              download: bool = False):
     # Setup up the workspace like normal
     lab = setup_workspace(args, log_file=log_file, log_prefix=log_prefix, banner_msg=banner_msg)
 
     # Double check the model.
     mm = lab.model_manager(model_name)
     if not mm.get_model_config().exists() and download:
-        # See if we can use the zoo
+        # Attempt to use the model zoo.
         jb_zoo.ensure_model(lab, model_name)
 
-    # Now, the model should be there or have failed
+    # At this point either the model exists or a failure occurred.
     mm.ensure_model_directory()
     mm.setup()
     return lab
-

--- a/juneberry/tensorflow/evaluation/evaluator.py
+++ b/juneberry/tensorflow/evaluation/evaluator.py
@@ -39,6 +39,7 @@ import juneberry.tensorflow.data as tf_data
 import juneberry.tensorflow.utils as tf_utils
 from juneberry.tensorflow.utils import TensorFlowPlatformDefinitions
 import juneberry.utils
+import juneberry.zoo as jb_zoo
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +149,13 @@ class Evaluator(EvaluatorBase):
             logger.info(f"Loading model {hdf5_file}...")
             self.model = tf.keras.models.load_model(hdf5_file)
             logger.info("...complete")
+
+            if not jb_zoo.check_allow_load_model(self.model_manager,
+                                                 lambda: tf_utils.hash_summary(self.model)):
+                msg = "The hash of the tensorflow model ARCHITECTURE did not match the expected hash in " \
+                      "hashes.json. Either delete the hash, retrain or get the correct model. Exiting Exiting"
+                logger.error(msg)
+                raise RuntimeError(msg)
 
         # If the model file doesn't exist...
         else:

--- a/juneberry/tensorflow/evaluation/evaluator.py
+++ b/juneberry/tensorflow/evaluation/evaluator.py
@@ -152,8 +152,8 @@ class Evaluator(EvaluatorBase):
 
             if not jb_zoo.check_allow_load_model(self.model_manager,
                                                  lambda: tf_utils.hash_summary(self.model)):
-                msg = "The hash of the tensorflow model ARCHITECTURE did not match the expected hash in " \
-                      "hashes.json. Either delete the hash, retrain or get the correct model. Exiting Exiting"
+                msg = "The hash of the TensorFlow MODEL ARCHITECTURE did not match the expected hash in " \
+                      "hashes.json. Either delete the hash, retrain, or get the correct model. Exiting."
                 logger.error(msg)
                 raise RuntimeError(msg)
 

--- a/juneberry/tensorflow/trainer.py
+++ b/juneberry/tensorflow/trainer.py
@@ -46,6 +46,7 @@ import juneberry.tensorflow.data as tf_data
 import juneberry.tensorflow.utils as tf_utils
 from juneberry.tensorflow.utils import TensorFlowPlatformDefinitions
 import juneberry.training.trainer
+import juneberry.zoo as jb_zoo
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +158,6 @@ class ClassifierTrainer(juneberry.training.trainer.Trainer):
         # Setup the model and dump the summary.
         self.setup_model()
 
-        # TODO: Change "get_pytorch_model_summary_path"
         tf_utils.save_summary(self.model, self.model_manager.get_model_summary_path())
 
     # ==========================
@@ -251,6 +251,10 @@ class ClassifierTrainer(juneberry.training.trainer.Trainer):
             juneberry.plotting.plot_training_summary_chart(self.results, self.model_manager)
 
         self._serialize_results()
+
+        logger.info("Updating hashes file...")
+        model_arch_hash = tf_utils.hash_summary(self.model)
+        jb_zoo.update_hashes_after_training(self.model_manager, model_arch_hash)
 
     # ==========================
 

--- a/juneberry/tensorflow/utils.py
+++ b/juneberry/tensorflow/utils.py
@@ -22,6 +22,8 @@
 #
 # ======================================================================================================================
 
+import hashlib
+import io
 import logging
 import sys
 
@@ -44,6 +46,25 @@ def save_summary(model, summary_file_path):
     sys.stdout = open(summary_file_path, 'w+', encoding="utf-8")
     model.summary()
     sys.stdout = orig
+
+
+def hash_summary(model):
+    # Swap out a string buffer, and capture the summary to it
+    output = io.StringIO()
+    orig = sys.stdout
+    sys.stdout = output
+    model.summary()
+    sys.stdout = orig
+
+    # Hash it and stash off the digest before we destroy the buffer
+    hasher = hashlib.sha256()
+    hasher.update(output.getvalue().encode('utf-8'))
+    digest = hasher.hexdigest()
+
+    # Close object and discard memory buffer
+    output.close()
+
+    return digest
 
 
 def set_tensorflow_seeds(seed: int):

--- a/juneberry/tensorflow/utils.py
+++ b/juneberry/tensorflow/utils.py
@@ -49,19 +49,19 @@ def save_summary(model, summary_file_path):
 
 
 def hash_summary(model):
-    # Swap out a string buffer, and capture the summary to it
+    # Swap out a string buffer and capture the summary in the buffer.
     output = io.StringIO()
     orig = sys.stdout
     sys.stdout = output
     model.summary()
     sys.stdout = orig
 
-    # Hash it and stash off the digest before we destroy the buffer
+    # Hash the model summary and stash off the digest before destroying the buffer.
     hasher = hashlib.sha256()
     hasher.update(output.getvalue().encode('utf-8'))
     digest = hasher.hexdigest()
 
-    # Close object and discard memory buffer
+    # Close the object and discard the memory buffer.
     output.close()
 
     return digest

--- a/juneberry/zoo.py
+++ b/juneberry/zoo.py
@@ -31,6 +31,7 @@ from zipfile import ZipFile
 
 import requests
 
+from juneberry.config.hashes import Hashes
 import juneberry.filesystem as jb_fs
 from juneberry.lab import Lab
 from juneberry.onnx.utils import ONNXPlatformDefinitions
@@ -148,9 +149,9 @@ def _install_from_cache(lab: Lab, model_name: str) -> bool:
 
     # Make the model path in the models dir - Path.mkdir
     model_mgr = lab.model_manager(model_name)
-    model_mgr.model_dir_path.mkdir(parents=True)
+    model_mgr.model_dir_path.mkdir(parents=True, exist_ok=True)
 
-    # Unzip the contents into that directory - extract all
+    # The contents are in.
     with ZipFile(cache_zip_path) as myzip:
         myzip.extractall(model_mgr.model_dir_path)
 
@@ -162,7 +163,7 @@ def ensure_model(lab: Lab, model_name: str, no_cache: bool = False) -> None:
     :param lab: The lab that contains the cache directory and model zoo url
     :param model_name: The model name to download.
     :param no_cache: Set to true to ignore what is in the cache and download again
-    :return:
+    :return: None
     """
     # Set up the proper zoo and model names
     zoo_url, model_name = _setup_zoo_and_model_name(lab, model_name)
@@ -170,6 +171,10 @@ def ensure_model(lab: Lab, model_name: str, no_cache: bool = False) -> None:
     # If the model config exists, we are done
     model_mgr = lab.model_manager(model_name)
     if model_mgr.get_model_config().exists():
+        return
+
+    if zoo_url is None:
+        logger.info("No juneberry zoo specified, cannot download model.")
         return
 
     # By this point we are going to pull things and put into the cache.
@@ -185,6 +190,39 @@ def ensure_model(lab: Lab, model_name: str, no_cache: bool = False) -> None:
 
     # Install from cache
     _install_from_cache(lab, model_name)
+
+
+def check_allow_load_model(model_manager, summary_hash_fn) -> bool:
+    """
+    Checks to see if the model should be installed. If a hashes config file exists and
+    it has a model_archiecture key and that matchs the archiecture, then we are good to
+    go.
+    :param lab: The lab that contains the cache directory and model zoo url
+    :param model_name: The name of the model
+    :param summary_hash_fn: A function to call that will return the appropriate hash
+    value of the model summary. This will only be called if the a hash value exists to
+    compare agaist.
+    :return:
+    """
+    hashes_path = Path(model_manager.get_hashes_config())
+    if not hashes_path.exists():
+        # If no hashes config file exists just return.
+        logger.debug("No hashes.json file found, approving model load.")
+        return True
+
+    hashes = Hashes.load(hashes_path)
+    if hashes.model_architecture is None:
+        # No model architecture hash exists, retrn
+        logger.debug("No model_archirecture found in hashes.json, approving model load.")
+        return True
+
+    # Okay, now compare
+    if summary_hash_fn() == hashes.model_architecture:
+        logger.info("Model architecture hash found and matches architecture allow load.")
+        return True
+    else:
+        logger.info("Model architecture hash found and DOES NOT matches architecture, preventing load.")
+        return False
 
 
 def prepare_model_for_zoo(model_name: str, staging_zoo_dir: str, onnx: bool = True) -> str:
@@ -208,7 +246,7 @@ def prepare_model_for_zoo(model_name: str, staging_zoo_dir: str, onnx: bool = Tr
     model_mgr = jb_fs.ModelManager(model_name)
 
     with ZipFile(model_zip_path, "w") as zip_file:
-        zip_file.write(model_mgr.get_model_config(), "config.json")
+        zip_file.write(model_mgr.get_model_config(), model_mgr.get_model_config_filename())
 
         # TODO: This is fragile in that we won't zip just anything. We need some better way
         #  to do this. Of course, the user can just zip it themselves, so this is just a convenience.
@@ -225,7 +263,36 @@ def prepare_model_for_zoo(model_name: str, staging_zoo_dir: str, onnx: bool = Tr
             if path.exists():
                 zip_file.write(path, ONNXPlatformDefinitions().get_model_filename())
 
+        # Add the hash file if it exists
+        hashes_path = model_mgr.get_hashes_config()
+        if hashes_path.exists():
+            zip_file.write(hashes_path, model_mgr.get_hashes_config_filename())
+        else:
+            # If we have a latest hashes, then use it.
+            latest_hashes_path = model_mgr.get_latest_hashes_config()
+            if latest_hashes_path.exists():
+                zip_file.write(latest_hashes_path, model_mgr.get_hashes_config_filename())
+
     return str(model_zip_path.absolute())
+
+
+def update_hashes_file(hashes_path, model_architecture_hash: str = None):
+    if hashes_path.exists():
+        hashes = Hashes.load(hashes_path)
+    else:
+        hashes = Hashes()
+
+    if model_architecture_hash is not None:
+        hashes.model_architecture = model_architecture_hash
+    hashes.save(hashes_path)
+
+def update_hashes_after_training(model_mgr, model_architecture_hash: str = None):
+    # If we have an existing hash file, update it.
+    # Always update 'latest' as it is what we use when package a model for the zoo.
+    hashes_path = model_mgr.get_hashes_config()
+    if hashes_path.exists():
+        update_hashes_file(hashes_path, model_architecture_hash)
+    update_hashes_file(model_mgr.get_latest_hashes_config(), model_architecture_hash)
 
 
 def package_model():

--- a/juneberry/zoo.py
+++ b/juneberry/zoo.py
@@ -276,8 +276,8 @@ def prepare_model_for_zoo(model_name: str, staging_zoo_dir: str, onnx: bool = Tr
     return str(model_zip_path.absolute())
 
 
-def update_hashes_file(hashes_path, model_architecture_hash: str = None):
-    if hashes_path.exists():
+def update_hashes_file(hashes_path: str, model_architecture_hash: str = None) -> None:
+    if Path(hashes_path).exists():
         hashes = Hashes.load(hashes_path)
     else:
         hashes = Hashes()
@@ -286,12 +286,13 @@ def update_hashes_file(hashes_path, model_architecture_hash: str = None):
         hashes.model_architecture = model_architecture_hash
     hashes.save(hashes_path)
 
-def update_hashes_after_training(model_mgr, model_architecture_hash: str = None):
+
+def update_hashes_after_training(model_mgr, model_architecture_hash: str = None) -> None:
     # If we have an existing hash file, update it.
     # Always update 'latest' as it is what we use when package a model for the zoo.
     hashes_path = model_mgr.get_hashes_config()
     if hashes_path.exists():
-        update_hashes_file(hashes_path, model_architecture_hash)
+        update_hashes_file(str(hashes_path), model_architecture_hash)
     update_hashes_file(model_mgr.get_latest_hashes_config(), model_architecture_hash)
 
 


### PR DESCRIPTION
Wire zoo in jb_evaluate and classification training.

To test there are currently two models on artifactory that are copies of the PT and TF2 imagenette models.  So:

1) Set JUNEBERRY_MODEL_ZOO - "export JUNEBERRY_MODEL_ZOO=https://artifactory.sei.cmu.edu:443/artifactory/etc-docker/juneberry/models/"
2) Use zoo-pt-example - "jb_evaluate zoo-pt-example data_sets/data_sets/imagenette_unit_test.json"
3) Use zoo-tf-example - "jb_evaluate zoo-tf-example data_sets/data_sets/imagenette_unit_test.json"

They should download, instantiate and evaluate normally.