### PR TITLE
Feature/random sharpen

### DIFF
--- a/juneberry/detectron2/data.py
+++ b/juneberry/detectron2/data.py
@@ -153,7 +153,7 @@ def create_mapper(cfg, transforms, is_train: bool) -> DatasetMapper:
                 aug_list.append(transform)
             else:
                 adapter = TransformAdapter(transform)
-                adapter.check_for_methods()
+                #adapter.check_for_methods()
                 aug_list.append(adapter)
 
     return DatasetMapper(**args)

--- a/juneberry/image.py
+++ b/juneberry/image.py
@@ -33,7 +33,7 @@ import warnings
 
 import numpy as np
 from PIL import Image, ImageFilter, ImageOps
-import albumentations as A
+from albumentations import Blur, Sharpen
 
 logger = logging.getLogger(__name__)
 
@@ -483,10 +483,12 @@ def random_sharpen(image: Image):
     transform = None
     if scale < 1:
         scale = (1.0-scale) * 50.0
-        transform = A.augmentations.transforms.Blur(blur_limit=scale, p=1)
+        if scale < 3:
+            scale = 3
+        transform = Blur(blur_limit=scale, p=1)
     elif scale > 1:
         scale = scale - 1.0
-        transform = A.augmentations.transforms.Sharpen(alpha= (scale,scale), lightness=(1.0,1.0), p=1)
+        transform = Sharpen(alpha= (scale,scale), lightness=(1.0,1.0), p=1)
     else:
         return image
     return transform(image=image)['image']

--- a/juneberry/image.py
+++ b/juneberry/image.py
@@ -33,6 +33,7 @@ import warnings
 
 import numpy as np
 from PIL import Image, ImageFilter, ImageOps
+import albumentations as A
 
 logger = logging.getLogger(__name__)
 

--- a/juneberry/image.py
+++ b/juneberry/image.py
@@ -472,3 +472,20 @@ def insert_watermark_at_position(image: Image, watermark: Image, position_xy):
         image.paste(watermark, position_xy)
 
     return image
+
+
+def random_sharpen(image: Image):
+    """
+    Randomly blur or sharpen an image.
+    """
+    scale = random.uniform(0.8,1.1)
+    transform = None
+    if scale < 1:
+        scale = (1.0-scale) * 50.0
+        transform = A.augmentations.transforms.Blur(blur_limit=scale, p=1)
+    elif scale > 1:
+        scale = scale - 1.0
+        transform = A.augmentations.transforms.Sharpen(alpha= (scale,scale), lightness=(1.0,1.0), p=1)
+    else:
+        return image
+    return transform(image=image)['image']

--- a/juneberry/transforms/random_sharpen.py
+++ b/juneberry/transforms/random_sharpen.py
@@ -19,6 +19,10 @@ class RandomSharpen:
 		#	logger.error(f"Scale value out of range. Must be between 0.0 and 2.0"
 		#			f"EXITING.")
 		pass
+
+	def apply_image(self, image):
+		return self.__call__(image)
+
 	def __call__(self, image):
 		"""
 		Transformation function that is provided a PIL image.

--- a/juneberry/transforms/random_sharpen.py
+++ b/juneberry/transforms/random_sharpen.py
@@ -1,0 +1,28 @@
+#! /usr/bin/env python3
+
+"""
+Simple transformer for sharpening or blurring an image. Takes a float value based on a provided range
+which determines whether the image is to be blurred or sharpened.
+"""
+
+import logging
+import sys
+
+import juneberry.image as iutils
+
+logger = logging.getLogger(__name__)
+
+class RandomSharpen:
+	def __init__(self):
+		#self.scale = scale
+		#if self.scale < 0.0 or self.scale > 2.0:
+		#	logger.error(f"Scale value out of range. Must be between 0.0 and 2.0"
+		#			f"EXITING.")
+		pass
+	def __call__(self, image):
+		"""
+		Transformation function that is provided a PIL image.
+		:param image: The source PIL image.
+		:return: The transformed PIL image.
+		"""
+		return iutils.random_sharpen(image)


### PR DESCRIPTION
Working with Jordan to fix our approach to using custom transforms. 

Files changed:
- `juneberry/transforms/random_sharpen`
    - Changed this class to include `apply_image` which just returns the `__call__` routine.
    - This is needed because when using Detectron2 it checks to see if the transforms includes 1 of the 5 methods
        - `apply_image`
        -`apply_polygons`
        - `apply_box`
        - `apply_cords`
        - `apply_segmentation`

- `juneberry/image.py`
    - Changed how we import Albumentations transform classes
    - Added a guard to make sure our scale is between 3.0 and infinity for `Blur` 
    
NOTE: These changes allow us to use custom transforms and pass this check: https://github.com/cmu-sei/juneberry/blob/459e6d18337ff82495ea393324899fa80b605eff/juneberry/detectron2/data.py#L86