### PR TITLE
New Docker build fixes

### DIFF
--- a/.github/workflows/docker-image-cpudev.yml
+++ b/.github/workflows/docker-image-cpudev.yml
@@ -11,6 +11,18 @@ jobs:
 
     steps:
       -
+        name: Check base machine storage
+        run: df -h /
+      -
+        name: Delete unused packages and tools
+        run: sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell &&
+          sudo apt-get autoremove -y &&
+          sudo apt-get clean &&
+          rm -rf /usr/share/dotnet/
+      -
+        name: Check base machine storage (after delete)
+        run: df -h /
+      -
         name: Checkout
         uses: actions/checkout@v2
       -

--- a/.github/workflows/docker-image-cpudev.yml
+++ b/.github/workflows/docker-image-cpudev.yml
@@ -19,6 +19,7 @@ jobs:
           sudo apt-get autoremove -y &&
           sudo apt-get clean &&
           rm -rf /usr/share/dotnet/
+          rm -rf /opt/hostedtoolcache
       -
         name: Check base machine storage (after delete)
         run: df -h /

--- a/.github/workflows/docker-image-cudabricks-base.yml
+++ b/.github/workflows/docker-image-cudabricks-base.yml
@@ -10,9 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check docker storage
-        run: docker images
-      - name: Check base machine storage
+      -
+        name: Check base machine storage
+        run: df -h /
+      -
+        name: Delete unused packages and tools
+        run: sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell &&
+          sudo apt-get autoremove -y &&
+          sudo apt-get clean &&
+          rm -rf /usr/share/dotnet/
+      -
+        name: Check base machine storage (after delete)
         run: df -h /
       -
         name: Checkout

--- a/.github/workflows/docker-image-cudabricks-base.yml
+++ b/.github/workflows/docker-image-cudabricks-base.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check docker storage
+        run: docker images
+      - name: Check base machine storage
+        run: df -h /
       -
         name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/docker-image-cudabricks-base.yml
+++ b/.github/workflows/docker-image-cudabricks-base.yml
@@ -19,6 +19,7 @@ jobs:
           sudo apt-get autoremove -y &&
           sudo apt-get clean &&
           rm -rf /usr/share/dotnet/
+          rm -rf /opt/hostedtoolcache
       -
         name: Check base machine storage (after delete)
         run: df -h /

--- a/.github/workflows/docker-image-cudabricks.yml
+++ b/.github/workflows/docker-image-cudabricks.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Remove dangling docker images
-        run: docker image prune -f
-      - name: Check docker storage
-        run: docker images
+      - name: Check base machine storage
+        run: df -h /
+      - name: Delete unused dotnet package (15 GB)
+        run: rm -rf /usr/share/dotnet/
       - name: Check base machine storage
         run: df -h /
       -

--- a/.github/workflows/docker-image-cudabricks.yml
+++ b/.github/workflows/docker-image-cudabricks.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check docker storage
+        run: docker images
+      - name: Check base machine storage
+        run: df -h /
       -
         name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/docker-image-cudabricks.yml
+++ b/.github/workflows/docker-image-cudabricks.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Remove dangling docker images
-        run: docker image prune
+        run: docker image prune -f
       - name: Check docker storage
         run: docker images
       - name: Check base machine storage

--- a/.github/workflows/docker-image-cudabricks.yml
+++ b/.github/workflows/docker-image-cudabricks.yml
@@ -10,11 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check base machine storage
+      -
+        name: Check base machine storage
         run: df -h /
-      - name: Delete unused dotnet package (15 GB)
-        run: rm -rf /usr/share/dotnet/
-      - name: Check base machine storage
+      -
+        name: Delete unused packages and tools
+        run: sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell && 
+             sudo apt-get autoremove -y && 
+             sudo apt-get clean && 
+             rm -rf /usr/share/dotnet/
+      -
+        name: Check base machine storage (after delete)
         run: df -h /
       -
         name: Checkout

--- a/.github/workflows/docker-image-cudabricks.yml
+++ b/.github/workflows/docker-image-cudabricks.yml
@@ -19,6 +19,7 @@ jobs:
              sudo apt-get autoremove -y && 
              sudo apt-get clean && 
              rm -rf /usr/share/dotnet/
+             rm -rf /opt/hostedtoolcache
       -
         name: Check base machine storage (after delete)
         run: df -h /

--- a/.github/workflows/docker-image-cudabricks.yml
+++ b/.github/workflows/docker-image-cudabricks.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Remove dangling docker images
+        run: docker image prune
       - name: Check docker storage
         run: docker images
       - name: Check base machine storage

--- a/.github/workflows/docker-image-cudadev.yml
+++ b/.github/workflows/docker-image-cudadev.yml
@@ -11,6 +11,18 @@ jobs:
 
     steps:
       -
+        name: Check base machine storage
+        run: df -h /
+      -
+        name: Delete unused packages and tools
+        run: sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell &&
+          sudo apt-get autoremove -y &&
+          sudo apt-get clean &&
+          rm -rf /usr/share/dotnet/
+      -
+        name: Check base machine storage (after delete)
+        run: df -h /
+      -
         name: Checkout
         uses: actions/checkout@v2
       -

--- a/.github/workflows/docker-image-cudadev.yml
+++ b/.github/workflows/docker-image-cudadev.yml
@@ -19,6 +19,7 @@ jobs:
           sudo apt-get autoremove -y &&
           sudo apt-get clean &&
           rm -rf /usr/share/dotnet/
+          rm -rf /opt/hostedtoolcache
       -
         name: Check base machine storage (after delete)
         run: df -h /

--- a/docker/cpudev.Dockerfile
+++ b/docker/cpudev.Dockerfile
@@ -46,7 +46,7 @@ RUN pip3 install --upgrade pip
 # pycocotools) we can't have tensorflow moving to old versions.
 #RUN pip install tensorflow tensorflow-datasets
 # Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0
-RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
+RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0
 
 # ============ JUNEBERRY ============
 
@@ -56,7 +56,7 @@ RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    scikit-learn tensorboard==2.11.0 \
+    scikit-learn==0.24.2 tensorboard==2.11.0 \
     torch==1.13.0 torchvision==0.14.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \

--- a/docker/cpudev.Dockerfile
+++ b/docker/cpudev.Dockerfile
@@ -56,7 +56,7 @@ RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    sklearn==0.0.post1 tensorboard==2.11.0 \
+    sklearn tensorboard==2.11.0 \
     torch==1.13.0 torchvision==0.14.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
@@ -67,7 +67,7 @@ RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     tqdm==4.64.1 \
     pytest==7.2.0 pylint==2.15.8 \
     ray==2.1.0 jsonpath-ng==1.5.3 \
-    torchmetrics==0.11.0
+    torchmetrics==0.10.2
 
 # ============ DETECTRON2 ============
 

--- a/docker/cpudev.Dockerfile
+++ b/docker/cpudev.Dockerfile
@@ -56,7 +56,7 @@ RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    sklearn tensorboard==2.11.0 \
+    scikit-learn tensorboard==2.11.0 \
     torch==1.13.0 torchvision==0.14.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \

--- a/docker/cpudev.Dockerfile
+++ b/docker/cpudev.Dockerfile
@@ -61,7 +61,7 @@ RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
     opacus==1.3.0 \
-    protobuf==3.19.6 onnx==1.12.0 onnxruntime \
+    protobuf==4.22.1 onnx==1.12.0 onnxruntime \
     tf2onnx==1.13.0 \
     opencv-python==4.6.0.66 \
     tqdm==4.64.1 \

--- a/docker/cpudev.Dockerfile
+++ b/docker/cpudev.Dockerfile
@@ -96,7 +96,7 @@ ENV JUNEBERRY_TENSORBOARD="/tensorboard"
 # ============ CONVENIENCE ============
 
 # Add some settings to the bashrc to make it easier for folks to know we are in a container
-ENV JUNEBERRY_CONTAINER_VERSION="cpudev:v13.0"
+ENV JUNEBERRY_CONTAINER_VERSION="cpudev:v13.1"
 RUN echo "PS1='${debian_chroot:+($debian_chroot)}\u@\h+CPUDev:\w\$ '" >> /root/.bashrc; \
     echo "alias ll='ls -l --color=auto'" >> /root/.bashrc; \
     echo "alias jb_comp='source /juneberry/scripts/juneberry_completion.sh'" >> /root/.bashrc; \

--- a/docker/cpudev.Dockerfile
+++ b/docker/cpudev.Dockerfile
@@ -48,7 +48,7 @@ RUN pip3 install --upgrade pip
 RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0 \
                 tensorrt==8.6.0 tf2onnx==1.13.0
 # Suppress Tensorflow Warnings
-ENV TF_CPP_MIN_LOG_LEVEL = "3"
+ENV TF_CPP_MIN_LOG_LEVEL="3"
 
 # ============ JUNEBERRY ============
 

--- a/docker/cpudev.Dockerfile
+++ b/docker/cpudev.Dockerfile
@@ -46,7 +46,7 @@ RUN pip3 install --upgrade pip
 # pycocotools) we can't have tensorflow moving to old versions.
 #RUN pip install tensorflow tensorflow-datasets
 # Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0
-RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0
+RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0
 
 # ============ JUNEBERRY ============
 
@@ -56,7 +56,7 @@ RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    scikit-learn==0.24.2 tensorboard==2.11.0 \
+    scikit-learn==0.24.2 \
     torch==1.13.0 torchvision==0.14.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \

--- a/docker/cpudev.Dockerfile
+++ b/docker/cpudev.Dockerfile
@@ -48,7 +48,7 @@ RUN pip3 install --upgrade pip
 RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0 \
                 tensorrt==8.6.0 tf2onnx==1.13.0
 # Suppress Tensorflow Warnings
-ENV TF_CPP_MIN_LOG_LEVEL = "2"
+ENV TF_CPP_MIN_LOG_LEVEL = "3"
 
 # ============ JUNEBERRY ============
 

--- a/docker/cpudev.Dockerfile
+++ b/docker/cpudev.Dockerfile
@@ -44,9 +44,11 @@ RUN pip3 install --upgrade pip
 # We install tensorflow FIRST because it is very picky about versions of things such
 # as numpy. And when other things need numpy (such as to compile against it, such as
 # pycocotools) we can't have tensorflow moving to old versions.
-#RUN pip install tensorflow tensorflow-datasets
-# Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0
-RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0
+# Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.12.0
+RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0 \
+                tensorrt==8.6.0 tf2onnx==1.13.0
+# Suppress Tensorflow Warnings
+ENV TF_CPP_MIN_LOG_LEVEL = "2"
 
 # ============ JUNEBERRY ============
 
@@ -61,8 +63,7 @@ RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
     opacus==1.3.0 \
-    protobuf==4.22.1 onnx==1.12.0 onnxruntime \
-    tf2onnx==1.13.0 \
+    protobuf==3.20.3 onnx==1.13.1 onnxruntime==1.14.1 \
     opencv-python==4.6.0.66 \
     tqdm==4.64.1 \
     pytest==7.2.0 pylint==2.15.8 \

--- a/docker/cudadev.Dockerfile
+++ b/docker/cudadev.Dockerfile
@@ -46,7 +46,7 @@ RUN pip3 install --upgrade pip
 RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0 \
                 tensorrt==8.6.0 tf2onnx==1.13.0
 # Suppress Tensorflow Warnings
-ENV TF_CPP_MIN_LOG_LEVEL = "2"
+ENV TF_CPP_MIN_LOG_LEVEL = "3"
 
 # ============ JUNEBERRY ============
 

--- a/docker/cudadev.Dockerfile
+++ b/docker/cudadev.Dockerfile
@@ -43,7 +43,7 @@ RUN pip3 install --upgrade pip
 # as numpy. And when other things need numpy (such as to compile against it, such as
 # pycocotools) we can't have tensorflow moving to old versions.
 # Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0
-RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0
+RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0
 
 # ============ JUNEBERRY ============
 
@@ -54,7 +54,7 @@ RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    scikit-learn==0.24.2 tensorboard==2.11.0 \
+    scikit-learn==0.24.2 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
     opacus==1.3.0 protobuf==4.22.1 onnx==1.12.0 onnxruntime-gpu==1.13.1 \

--- a/docker/cudadev.Dockerfile
+++ b/docker/cudadev.Dockerfile
@@ -54,7 +54,7 @@ RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    sklearn tensorboard==2.11.0 \
+    scikit-learn tensorboard==2.11.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
     opacus==1.3.0 protobuf==3.19.6 onnx==1.12.0 onnxruntime-gpu==1.13.1 \

--- a/docker/cudadev.Dockerfile
+++ b/docker/cudadev.Dockerfile
@@ -94,7 +94,7 @@ ENV JUNEBERRY_TENSORBOARD="/tensorboard"
 # ============ CONVENIENCE ============
 
 # Add some settings to the bashrc to make it easier for folks to know we are in a container
-ENV JUNEBERRY_CONTAINER_VERSION="cudadev:v13.0"
+ENV JUNEBERRY_CONTAINER_VERSION="cudadev:v13.1"
 RUN echo "PS1='${debian_chroot:+($debian_chroot)}\u@\h+CudaDev:\w\$ '" >> /root/.bashrc; \
     echo "alias ll='ls -l --color=auto'" >> /root/.bashrc; \
     echo "alias jb_comp='source /juneberry/scripts/juneberry_completion.sh'" >> /root/.bashrc; \

--- a/docker/cudadev.Dockerfile
+++ b/docker/cudadev.Dockerfile
@@ -46,7 +46,7 @@ RUN pip3 install --upgrade pip
 RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0 \
                 tensorrt==8.6.0 tf2onnx==1.13.0
 # Suppress Tensorflow Warnings
-ENV TF_CPP_MIN_LOG_LEVEL = "3"
+ENV TF_CPP_MIN_LOG_LEVEL="3"
 
 # ============ JUNEBERRY ============
 

--- a/docker/cudadev.Dockerfile
+++ b/docker/cudadev.Dockerfile
@@ -42,8 +42,11 @@ RUN pip3 install --upgrade pip
 # We install tensorflow FIRST because it is very picky about versions of things such
 # as numpy. And when other things need numpy (such as to compile against it, such as
 # pycocotools) we can't have tensorflow moving to old versions.
-# Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0
-RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0
+# Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.12.0
+RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0 \
+                tensorrt==8.6.0 tf2onnx==1.13.0
+# Suppress Tensorflow Warnings
+ENV TF_CPP_MIN_LOG_LEVEL = "2"
 
 # ============ JUNEBERRY ============
 
@@ -57,8 +60,7 @@ RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     scikit-learn==0.24.2 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
-    opacus==1.3.0 protobuf==4.22.1 onnx==1.12.0 onnxruntime-gpu==1.13.1 \
-    tf2onnx==1.13.0 \
+    opacus==1.3.0 protobuf==3.20.3 onnx==1.13.1 onnxruntime-gpu==1.14.1 \
     opencv-python==4.6.0.66 \
     tqdm==4.64.1 \
     pytest==7.2.0 pylint==2.15.8 \

--- a/docker/cudadev.Dockerfile
+++ b/docker/cudadev.Dockerfile
@@ -43,7 +43,7 @@ RUN pip3 install --upgrade pip
 # as numpy. And when other things need numpy (such as to compile against it, such as
 # pycocotools) we can't have tensorflow moving to old versions.
 # Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0
-RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
+RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0
 
 # ============ JUNEBERRY ============
 
@@ -54,7 +54,7 @@ RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    scikit-learn tensorboard==2.11.0 \
+    scikit-learn==0.24.2 tensorboard==2.11.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
     opacus==1.3.0 protobuf==3.19.6 onnx==1.12.0 onnxruntime-gpu==1.13.1 \

--- a/docker/cudadev.Dockerfile
+++ b/docker/cudadev.Dockerfile
@@ -57,7 +57,7 @@ RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     scikit-learn==0.24.2 tensorboard==2.11.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
-    opacus==1.3.0 protobuf==3.19.6 onnx==1.12.0 onnxruntime-gpu==1.13.1 \
+    opacus==1.3.0 protobuf==4.22.1 onnx==1.12.0 onnxruntime-gpu==1.13.1 \
     tf2onnx==1.13.0 \
     opencv-python==4.6.0.66 \
     tqdm==4.64.1 \

--- a/docker/cudadev.Dockerfile
+++ b/docker/cudadev.Dockerfile
@@ -54,7 +54,7 @@ RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    sklearn==0.0.post1 tensorboard==2.11.0 \
+    sklearn tensorboard==2.11.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
     opacus==1.3.0 protobuf==3.19.6 onnx==1.12.0 onnxruntime-gpu==1.13.1 \
@@ -63,7 +63,7 @@ RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     tqdm==4.64.1 \
     pytest==7.2.0 pylint==2.15.8 \
     ray==2.1.0 jsonpath-ng==1.5.3 \
-    torchmetrics==0.11.0
+    torchmetrics==0.10.2
 
 # ============ DETECTRON2 ============
 

--- a/docker/databricks/base.Dockerfile
+++ b/docker/databricks/base.Dockerfile
@@ -52,7 +52,7 @@ RUN pip3 install --upgrade pip
 # as numpy. And when other things need numpy (such as to compile against it, such as
 # pycocotools) we can't have tensorflow moving to old versions.
 # Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0
-RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
+RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0
 
 # ============ JUNEBERRY ============
 
@@ -63,7 +63,7 @@ RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    scikit-learn tensorboard==2.11.0 \
+    scikit-learn==0.24.2 tensorboard==2.11.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
     opacus==1.3.0 protobuf==3.19.6 onnx==1.12.0 onnxruntime-gpu==1.13.1 \

--- a/docker/databricks/base.Dockerfile
+++ b/docker/databricks/base.Dockerfile
@@ -52,7 +52,7 @@ RUN pip3 install --upgrade pip
 # as numpy. And when other things need numpy (such as to compile against it, such as
 # pycocotools) we can't have tensorflow moving to old versions.
 # Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0
-RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0
+RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0
 
 # ============ JUNEBERRY ============
 
@@ -63,7 +63,7 @@ RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    scikit-learn==0.24.2 tensorboard==2.11.0 \
+    scikit-learn==0.24.2 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
     opacus==1.3.0 protobuf==4.22.1 onnx==1.12.0 onnxruntime-gpu==1.13.1 \

--- a/docker/databricks/base.Dockerfile
+++ b/docker/databricks/base.Dockerfile
@@ -55,7 +55,7 @@ RUN pip3 install --upgrade pip
 RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0 \
                 tensorrt==8.6.0 tf2onnx==1.13.0
 # Suppress Tensorflow Warnings
-ENV TF_CPP_MIN_LOG_LEVEL = "2"
+ENV TF_CPP_MIN_LOG_LEVEL = "3"
 
 # ============ JUNEBERRY ============
 

--- a/docker/databricks/base.Dockerfile
+++ b/docker/databricks/base.Dockerfile
@@ -55,7 +55,7 @@ RUN pip3 install --upgrade pip
 RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0 \
                 tensorrt==8.6.0 tf2onnx==1.13.0
 # Suppress Tensorflow Warnings
-ENV TF_CPP_MIN_LOG_LEVEL = "3"
+ENV TF_CPP_MIN_LOG_LEVEL="3"
 
 # ============ JUNEBERRY ============
 

--- a/docker/databricks/base.Dockerfile
+++ b/docker/databricks/base.Dockerfile
@@ -63,7 +63,7 @@ RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    sklearn tensorboard==2.11.0 \
+    scikit-learn tensorboard==2.11.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
     opacus==1.3.0 protobuf==3.19.6 onnx==1.12.0 onnxruntime-gpu==1.13.1 \

--- a/docker/databricks/base.Dockerfile
+++ b/docker/databricks/base.Dockerfile
@@ -63,7 +63,7 @@ RUN pip install tensorflow==2.11.0 tensorflow-datasets==4.7.0
 RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     doit==0.36.0 numpy==1.22.2 pycocotools==2.0.6 matplotlib==3.6.2 \
     pillow==9.3.0 prodict==0.8.18 hjson==3.1.0 jsonschema==4.17.0 \
-    sklearn==0.0.post1 tensorboard==2.11.0 \
+    sklearn tensorboard==2.11.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
     opacus==1.3.0 protobuf==3.19.6 onnx==1.12.0 onnxruntime-gpu==1.13.1 \
@@ -72,7 +72,7 @@ RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     tqdm==4.64.1 \
     pytest==7.2.0 pylint==2.15.8 \
     ray==2.1.0 jsonpath-ng==1.5.3 \
-    torchmetrics==0.11.0
+    torchmetrics==0.10.2
 
 # ============ DETECTRON2 ============
 

--- a/docker/databricks/base.Dockerfile
+++ b/docker/databricks/base.Dockerfile
@@ -139,7 +139,7 @@ ENV JUNEBERRY_TENSORBOARD="/tensorboard"
 # ============ CONVENIENCE ============
 
 # Add some settings to the bashrc to make it easier for folks to know we are in a container
-ENV JUNEBERRY_CONTAINER_VERSION="cudabricks:v13.0"
+ENV JUNEBERRY_CONTAINER_VERSION="cudabricks:v13.1"
 RUN echo "PS1='${debian_chroot:+($debian_chroot)}\u@\h+CudaBricks:\w\$ '" >> /root/.bashrc; \
     echo "alias ll='ls -l --color=auto'" >> /root/.bashrc; \
     echo "alias jb_comp='source /juneberry/scripts/juneberry_completion.sh'" >> /root/.bashrc; \

--- a/docker/databricks/base.Dockerfile
+++ b/docker/databricks/base.Dockerfile
@@ -66,7 +66,7 @@ RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     scikit-learn==0.24.2 tensorboard==2.11.0 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
-    opacus==1.3.0 protobuf==3.19.6 onnx==1.12.0 onnxruntime-gpu==1.13.1 \
+    opacus==1.3.0 protobuf==4.22.1 onnx==1.12.0 onnxruntime-gpu==1.13.1 \
     tf2onnx==1.13.0 \
     opencv-python==4.6.0.66 \
     tqdm==4.64.1 \

--- a/docker/databricks/base.Dockerfile
+++ b/docker/databricks/base.Dockerfile
@@ -51,8 +51,11 @@ RUN pip3 install --upgrade pip
 # We install tensorflow FIRST because it is very picky about versions of things such
 # as numpy. And when other things need numpy (such as to compile against it, such as
 # pycocotools) we can't have tensorflow moving to old versions.
-# Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0
-RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0
+# Tensorflow: https://github.com/tensorflow/tensorflow/releases/tag/v2.12.0
+RUN pip install tensorflow==2.12.0 tensorflow-datasets==4.7.0 tensorboard==2.12.0 \
+                tensorrt==8.6.0 tf2onnx==1.13.0
+# Suppress Tensorflow Warnings
+ENV TF_CPP_MIN_LOG_LEVEL = "2"
 
 # ============ JUNEBERRY ============
 
@@ -66,8 +69,7 @@ RUN pip3 install adversarial-robustness-toolbox==1.12.2 \
     scikit-learn==0.24.2 \
     torch-summary==1.4.5 albumentations==1.3.0 \
     pandas==1.4.4 brambox==4.1.1 pyyaml==6.0 natsort==8.2.0 \
-    opacus==1.3.0 protobuf==4.22.1 onnx==1.12.0 onnxruntime-gpu==1.13.1 \
-    tf2onnx==1.13.0 \
+    opacus==1.3.0 protobuf==3.20.3 onnx==1.13.1 onnxruntime-gpu==1.14.1 \
     opencv-python==4.6.0.66 \
     tqdm==4.64.1 \
     pytest==7.2.0 pylint==2.15.8 \

--- a/juneberry/pytorch/processing.py
+++ b/juneberry/pytorch/processing.py
@@ -129,9 +129,9 @@ def setup_cuda_device(num_gpus, gpu):
     else:
         assert gpu < num_gpus
         device = torch.device("cuda:" + str(gpu))
-        torch.cuda.set_device(device)
         # Adding LOCAL_RANK env to support pytorch 22.11 upgrade
-        os.environ['LOCAL_RANK'] = str(device)
+        os.environ['LOCAL_RANK'] = str(gpu)
+        torch.cuda.set_device(device)
 
     return device
 

--- a/juneberry/pytorch/processing.py
+++ b/juneberry/pytorch/processing.py
@@ -131,7 +131,7 @@ def setup_cuda_device(num_gpus, gpu):
         device = torch.device("cuda:" + str(gpu))
         torch.cuda.set_device(device)
         # Adding LOCAL_RANK env to support pytorch 22.11 upgrade
-        os.environ['LOCAL_RANK'] = str(torch.cuda.current_device())
+        os.environ['LOCAL_RANK'] = str(device)
 
     return device
 


### PR DESCRIPTION
### **v13.1 Updates**

**.github/workflows/*.yml Updates**
Added in steps into the workflow to remove unused packages before we build and push. We were Fixes `no storage left on device` error 

**Dockerfile changes:**
Updated to `Tensorflow 2.12.0`

Supressed Tensorflow Warnings with `TF_CPP_MIN_LOG_LEVEL = "2"`

Fixing pytest error experienced in newest Docker build release:
`accuracy() missing 3 required positional arguments: 'preds', 'target', and 'task'`

The issue seems to stem from the update made to torchmetrics (`0.10.2` --> `0.11.0`) and changed how the `accuracy()` function is used. Specifically, it seems to look for `task` as a required positional argument. Reverting back to `torchmetrics=0.10.2` seems to fix the error we get from our pytest.

Also unpinned from `sklearn` version since `0.0.post1` does not resolve to anything. Also updated to new naming convention for sklearn `scikit-learn`

**juneberry/pytorch/processing.py changes:**
Swapping from `os.environ['LOCAL_RANK'] = str(torch.cuda.current_device())` to `os.environ['LOCAL_RANK'] = str(gpu)` fixed the cuda error when using `cpudev`